### PR TITLE
EOS-12089 : NFS: mero singlenode: ganesha service is failing to start

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
+++ b/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
@@ -89,12 +89,12 @@ function motr_lib_init {
 	log "Initializing motr_lib..."
 
 	# Create motr_lib global idx
-	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
+	run m0kv -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
 		"$KVS_GLOBAL_FID"
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib Global index"
 
 	# Create motr_lib fs_meta idx
-	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
+	run m0kv -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index create\
 		"$KVS_NS_META_FID"
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib fs_meta index"
 }
@@ -303,9 +303,9 @@ function cortx_nfs_cleanup {
 	systemctl status nfs-ganesha > /dev/null && systemctl stop nfs-ganesha
 
 	# Drop index if previosly created
-	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
+	run m0kv -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
 		"$KVS_GLOBAL_FID"
-	run m0mt -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
+	run m0kv -l $LOC_EP -h $HA_EP -p $PROFILE -f $PROC_FID index drop\
 		"$KVS_NS_META_FID"
 
 	# Restore ganesha.conf, remove export entries.


### PR DESCRIPTION
## EOS-12089 : NFS: mero singlenode: ganesha service is failing to start due to panic
https://jts.seagate.com/browse/EOS-12809

## Solution Overview
Incorrect clovis utility (m0mt) was being used for creating indexes in nfs_setup.
m0kv is the correct utility that should be used. This has been fixed in nfs_setup.sh and motr_lib_init.shts

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing 
- [x] **Documentation:** _This patch and merge request have up to date description_

## What doesn't work
nfs_setup script works fine, but the the filesystem is not exported. This seems due to the PNFS related config blocks that have been added, needs more investigation.
@pratyush-seagate  @AtitaShirwaikar 

## Workarounds : 
Remove the PNFS block from ganesha.conf or from nfs_setup. After this, the filesystem is exported correctly and cthon passes.