### PR TITLE
EOS-12238: pNFS: MDS: Add preliminary support for multiple layout on same file object

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
+++ b/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
@@ -116,6 +116,7 @@ set(LIBCONFIG libconfig)
 
 SET(fsalkvsfs_LIB_SRCS
    fsal_internal.c
+   fsal_global_tables.c
    main.c
    export.c
    handle.c

--- a/src/FSAL/FSAL_CORTXFS/fsal_global_tables.c
+++ b/src/FSAL/FSAL_CORTXFS/fsal_global_tables.c
@@ -1,0 +1,224 @@
+/**
+ * Filename:         fsal_global_tables.c
+ * Description:      FSAL CORTXFS's global table implementation related
+ *                   data structures and associated APIs
+ * Do NOT modify or remove this copyright and confidentiality notice!
+ * Copyright (c) 2020, Seagate Technology, LLC.
+ * The code contained herein is CONFIDENTIAL to Seagate Technology, LLC.
+ * Portions are also trade secret. Any use, duplication, derivation,
+ * distribution or disclosure of this code, for any reason, not expressly
+ * authorized is prohibited. All other rights are expressly reserved by
+ * Seagate Technology, LLC.
+ * Author: Pratyush Kumar Khan <pratyush.k.khan@seagate.com>
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <libgen.h>		/* used for 'dirname' */
+#include <pthread.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <mntent.h>
+#include "gsh_list.h"
+#include "fsal.h"
+#include "fsal_internal.h"
+#include "fsal_convert.h"
+#include "FSAL/fsal_config.h"
+#include "FSAL/fsal_commonlib.h"
+#include "kvsfs_methods.h"
+#include "nfs_exports.h"
+#include "nfs_creds.h"
+#include "pnfs_utils.h"
+#include <stdbool.h>
+#include <arpa/inet.h>
+
+
+#define CORTXFS_HASH_TABLE_SIZE 64
+
+struct cortxfs_hash_elem {
+	uint16_t helm_ref; // TODO: implement it
+	void *helm;
+	size_t helm_size;
+	LIST_ENTRY(cortxfs_hash_elem) helm_link;
+};
+
+struct cortxfs_hash_bucket {
+	pthread_mutex_t hbt_mutex;
+	LIST_HEAD(hbt_list, cortxfs_hash_elem) hbt_chain;
+};
+
+struct cortxfs_hash_table {
+	struct cortxfs_hash_bucket ht_buckets[CORTXFS_HASH_TABLE_SIZE];
+};
+
+struct cortxfs_gtbl {
+	enum cortxfs_gtbl_types gt_type;
+	struct cortxfs_hash_table gt_ht;
+	/**
+	 * TODO: add private ctx and recall handler for async free
+	 * This will be needed when a HT elem (e.g. a layout) with non-zero
+	 * references are being removed. This removal should trigger the
+	 * associated table's recall handler, that handler will inform the
+	 * client that the active layout is being removed.
+	 */
+};
+
+static struct cortxfs_gtbl g_tbls[CORTXFS_GTBL_STATE_END];
+
+static void gtbl_htbl_ini(struct cortxfs_hash_table *ht)
+{
+	int rc;
+	int idx = 0;
+
+	memset(ht, 0, sizeof(*ht));
+
+	while (idx < CORTXFS_HASH_TABLE_SIZE) {
+		rc = pthread_mutex_init(&ht->ht_buckets[idx].hbt_mutex, NULL);
+		dassert(rc == 0);
+		idx++;
+	}
+}
+
+static void gtbl_htbl_fini(struct cortxfs_hash_table *ht)
+{
+	int rc;
+	int idx = 0;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+
+	memset(ht, 0, sizeof(*ht));
+
+	while (idx < CORTXFS_HASH_TABLE_SIZE) {
+		hbt = &ht->ht_buckets[idx];
+
+		while (!LIST_EMPTY(&hbt->hbt_chain)) {
+			helem = LIST_FIRST(&hbt->hbt_chain);
+			LIST_REMOVE(helem, helm_link);
+			// TODO: if helm_ref != 0, use recall/upcall/teardown
+			gsh_free(helem->helm);
+			gsh_free(helem);
+		}
+
+		rc = pthread_mutex_destroy(&ht->ht_buckets[idx].hbt_mutex);
+		dassert(rc == 0);
+		idx++;
+	}
+}
+
+void gtbl_ini(void)
+{
+	gtbl_htbl_ini(&g_tbls[CORTXFS_GTBL_STATE_LAYOUTS].gt_ht);
+	// TODO: add future tables here, one global for each type
+}
+
+void gtbl_fini(void)
+{
+	gtbl_htbl_fini(&g_tbls[CORTXFS_GTBL_STATE_LAYOUTS].gt_ht);
+	// TODO: add future tables here, one global for each type
+}
+
+int gtbl_add_elem(enum cortxfs_gtbl_types type, void *elem, size_t elem_size,
+		   uint64_t key)
+{
+	int rc, rc1 = 0;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+	uint16_t hkey = key % CORTXFS_HASH_TABLE_SIZE;
+
+	dassert(type >= CORTXFS_GTBL_STATE_END);
+	dassert(elem != NULL);
+
+	hbt = &g_tbls[type].gt_ht.ht_buckets[hkey];
+
+	rc = pthread_mutex_lock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	LIST_FOREACH(helem, &hbt->hbt_chain, helm_link) {
+		if ((helem->helm_size == elem_size) &&
+		    (memcmp(helem->helm, elem, elem_size) == 0)) {
+			// already present, do nothing
+			rc1 = EEXIST;
+			goto out;
+		}
+	}
+
+	helem = gsh_calloc(1, sizeof(*helem));
+	dassert(helem != NULL);
+	helem->helm = elem;
+	LIST_INSERT_HEAD(&hbt->hbt_chain, helem, helm_link);
+
+out:
+	rc = pthread_mutex_unlock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	return rc1;
+}
+
+void * gtbl_find_elem(enum cortxfs_gtbl_types type, const void *elem,
+			     size_t elem_size, uint64_t key)
+{
+	int rc;
+	void *elem_ret = NULL;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+	uint16_t hkey = key % CORTXFS_HASH_TABLE_SIZE;
+
+	dassert(type >= CORTXFS_GTBL_STATE_END);
+	dassert(elem != NULL);
+
+	hbt = &g_tbls[type].gt_ht.ht_buckets[hkey];
+
+	rc = pthread_mutex_lock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	LIST_FOREACH(helem, &hbt->hbt_chain, helm_link) {
+		if ((helem->helm_size == elem_size) &&
+		    (memcmp(helem->helm, elem, elem_size) == 0)) {
+			elem_ret = helem->helm;
+			break;
+		}
+	}
+
+	rc = pthread_mutex_unlock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	return elem_ret;
+}
+
+void * gtbl_remove_elem(enum cortxfs_gtbl_types type, const void *elem,
+			   size_t elem_size, uint64_t key)
+{
+	int rc;
+	void *elem_rmv = NULL;
+	struct cortxfs_hash_bucket *hbt;
+	struct cortxfs_hash_elem *helem;
+	uint16_t hkey = key % CORTXFS_HASH_TABLE_SIZE;
+
+	dassert(elem != NULL);
+
+	hbt = &g_tbls[type].gt_ht.ht_buckets[hkey];
+
+	rc = pthread_mutex_lock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	LIST_FOREACH(helem, &hbt->hbt_chain, helm_link) {
+		if ((helem->helm_size == elem_size) &&
+		    (memcmp(helem->helm, elem, elem_size) == 0)) {
+			elem_rmv = helem->helm;
+			break;
+		}
+	}
+
+	if (elem_rmv) {
+		LIST_REMOVE(helem, helm_link);
+		gsh_free(helem);
+	}
+
+	rc = pthread_mutex_unlock(&hbt->hbt_mutex);
+	dassert(rc == 0);
+
+	return elem_rmv;
+}

--- a/src/FSAL/FSAL_CORTXFS/fsal_internal.h
+++ b/src/FSAL/FSAL_CORTXFS/fsal_internal.h
@@ -102,4 +102,51 @@ void export_ops_pnfs(struct export_ops *ops);
 void handle_ops_pnfs(struct fsal_obj_ops *ops);
 void kvsfs_pnfs_ds_ops_init(struct fsal_pnfs_ds_ops *ops);
 
+enum cortxfs_gtbl_types {
+	CORTXFS_GTBL_CLIENT = 0,
+	CORTXFS_GTBL_STATE_OPEN,
+	CORTXFS_GTBL_STATE_BR_LOCKS,
+	CORTXFS_GTBL_STATE_DELEGS,
+	CORTXFS_GTBL_STATE_LAYOUTS,
+	CORTXFS_GTBL_STATE_END
+};
+
+/**
+ * Initialize the CORTXFS FSAL's global tables
+ */
+void gtbl_ini(void);
+
+/**
+ * Free the CORTXFS FSAL's global tables
+ */
+void gtbl_fini(void);
+
+/**
+ * Add an entry to CORTXFS FSAL's global table
+ * Caller must pass pre-allocated elem
+ * Returns 0 if success, else error code
+ */
+int gtbl_add_elem(enum cortxfs_gtbl_types type, void *elem,
+		   size_t elem_size, uint64_t key);
+
+/**
+ * Find an entry in CORTXFS FSAL's global table
+ * Caller must not free elem
+ */
+void * gtbl_find_elem(enum cortxfs_gtbl_types type, const void *elem,
+		      size_t elem_size, uint64_t key);
+
+/**
+ * Free an entry from CORTXFS FSAL's global table
+ * Returns NULL if not found
+ * Caller must free elem
+ */
+void * gtbl_remove_elem(enum cortxfs_gtbl_types type, const void *elem,
+			size_t elem_size, uint64_t key);
+
+/**
+ * Call this API when a layout on a file handle is being returned/freed
+ */
+void gtbl_layout_rmv_elem(const struct kvsfs_file_handle *lt_fh);
+
 #endif /* _FSAL_INTERNAL_H */

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -2674,6 +2674,7 @@ static fsal_status_t kvsfs_close2(struct fsal_obj_handle *obj_hdl,
 		break;
 	case STATE_TYPE_LAYOUT:
 		/* Unsupported (yet) state types. */
+		gtbl_layout_rmv_elem((const struct kvsfs_file_handle *) obj->handle);
 		T_TRACE("%s", "Closing layout state");
 		break;
 

--- a/src/FSAL/FSAL_CORTXFS/main.c
+++ b/src/FSAL/FSAL_CORTXFS/main.c
@@ -155,6 +155,8 @@ static fsal_status_t kvsfs_init_config(struct fsal_module *fsal_hdl,
 		}
 	}
 
+	gtbl_ini();
+
 	/**
 	 * TODO: In future when we move away from using ganesha.conf file
 	 * for the pNFS params and start using the /etc/cortx/cortxfs.conf
@@ -319,6 +321,8 @@ static int kvsfs_unload(struct fsal_module *fsal_hdl)
 			" unregister itself (%d).", rc);
 		goto out;
 	}
+
+	gtbl_fini();
 
 	rc = cfs_fini();
 	if (rc) {


### PR DESCRIPTION
# EOS-12238: pNFS: MDS: Add preliminary support for multiple layout on same file object

## Problem Description
EOS-10912 adds support for multiple DS with multi node. After this, we will be giving layout of a whole file to a client, but a layoutget conflict detection approach should be in place so that multiple layouts can not be given for same file object simultaneously, as in the absence of global file open state, this will cause data corruption if multiple writes from multiple clients/processes are performed in parallel. This task will be used to implement the rudimentary enforcement support for this cause. As discussed in the team 2's scrum today, we will use an in-memory hash table for filesystem objects to track active layouts. When this design will be used later to support global open states, then we can stop using this layout specific enforcement.

## Solution Overview
1) Add support for in-memory hash table for CORTXFS FSAL and associated APIs
2) Add support for global layout table
3) Track granted layouts based on the file handle and remove it when file closed/layout returned
4) Detect existing layouts for same file and reject layoutget requests

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_




        EOS-12238: pNFS: MDS: Add preliminary support for multiple layout on same file object

        Branch: EOS-12238
        List of added/modified/deleted files:
                new file:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/fsal_global_tables.c
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/fsal_internal.h
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/handle.c
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/main.c
                modified:   kvsfs-ganesha/src/FSAL/FSAL_KVSFS/mds.c

        Change description:
                1) Add support for in-memory hash table for CORTXFS FSAL and associated APIs
                2) Add support for global layout table
                3) Track granted layouts based on the file handle and remove it when file closed/layout returned
                4) Detect existing layouts for same file and reject layoutget requests

        Unit test (on LABVM):
                pNFS two VM dual role/one MDS, one DS test using provisioning and mero multi node, try to get layout multiple
                non-pNFS IO, UT

        Current change TODO:
                Implement timer thread to detect expired layouts and clean them
                Support for global open and layouts states instead of only current file handles
                Add support for references for hash elements, and use of ref. with provision for caller's ctx and async free

