### PR TITLE
EOS-10790: setup.yaml file for provisioning

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
+++ b/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
@@ -71,7 +71,7 @@ function get_ip {
 function get_ep {
 	[ -n "$EP" ] && return || EP=1
 
-	host_name=$(hostname -f )
+	host_name=$(cat /etc/salt/minion_id)
 	hctl_status=$(hctl status --json | jq '.')
 
 	cluster_info=$(echo $hctl_status | jq '.nodes[]')

--- a/src/FSAL/FSAL_CORTXFS/conf/setup.yaml
+++ b/src/FSAL/FSAL_CORTXFS/conf/setup.yaml
@@ -1,0 +1,10 @@
+nfs_server:
+        init:
+                script: /opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh
+                args: init -q
+        config:
+                script: /opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh
+                args: config -q
+        reset:
+                script: /opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh
+                args: cleanup -q

--- a/src/FSAL/FSAL_CORTXFS/cortx-fs-ganesha.spec-in.cmake
+++ b/src/FSAL/FSAL_CORTXFS/cortx-fs-ganesha.spec-in.cmake
@@ -17,6 +17,7 @@ Provides: %{name} = %{version}-%{release}
 %define _fsal_ganesha_dir	@INSTALL_DIR_ROOT@/@PROJECT_NAME_BASE@/%{_fsal_ganesha_lib}
 %define _fsal_ganesha_lib_dir	%{_fsal_ganesha_dir}/lib
 %define _fsal_ganesha_bin_dir	%{_fsal_ganesha_dir}/bin
+%define _nfs_conf_dir @INSTALL_DIR_ROOT@/@PROJECT_NAME_BASE@/nfs/conf
 
 %description
 NFS-Ganesha FSAL for @PROJECT_NAME_BASE@-fs
@@ -36,10 +37,12 @@ mkdir -p %{buildroot}%{_fsal_ganesha_dir}
 mkdir -p %{buildroot}%{_fsal_ganesha_lib_dir}
 mkdir -p %{buildroot}%{_fsal_ganesha_bin_dir}
 mkdir -p %{buildroot}%{_libdir}/ganesha/
+mkdir -p %{buildroot}%{_nfs_conf_dir}
 cd %{_lib_path}
 install -m 755 lib%{_fsal_ganesha_lib}.so* %{buildroot}%{_fsal_ganesha_lib_dir}
 install -m 755 %{_nfs_setup_dir}/nfs_setup.sh %{buildroot}%{_fsal_ganesha_bin_dir}
 install -m 755 %{_nfs_setup_dir}/nfs_setup_legacy.sh %{buildroot}%{_fsal_ganesha_bin_dir}
+install -m 664 %{_nfs_setup_dir}/setup.yaml %{buildroot}%{_nfs_conf_dir}
 ln -s %{_fsal_ganesha_lib_dir}/lib%{_fsal_ganesha_lib}.so.4.2.0 %{buildroot}%{_libdir}/ganesha/libfsal%{_fs_lib}.so.4.2.0
 ln -s %{_fsal_ganesha_lib_dir}/lib%{_fsal_ganesha_lib}.so.4 %{buildroot}%{_libdir}/ganesha/libfsal%{_fs_lib}.so.4
 ln -s %{_fsal_ganesha_lib_dir}/lib%{_fsal_ganesha_lib}.so %{buildroot}%{_libdir}/ganesha/libfsal%{_fs_lib}.so
@@ -61,6 +64,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_sbindir}/nfs_setup
 %{_fsal_ganesha_bin_dir}/nfs_setup_legacy.sh
 %{_sbindir}/nfs_setup_legacy
+%{_nfs_conf_dir}/setup.yaml
 
 %changelog
 * Mon Jan 25 2019 Ashay Shirwadkar <ashay.shirwadkar@seagate.com> - 1.0.0


### PR DESCRIPTION
Description:
NFS is not integrated with Provisioning and HARE.
Jira: https://jts.seagate.com/browse/EOS-10790

Fix:
Added Setup.yaml file for provisioning to do automated setup.
Modified _nfs_setup.sh_ to get hostname from _'/etc/salt/minion_id'_

UT done
1. _setup.yaml_ file is getting copied to '_/opt/seagate/cortx/nfs/conf/setup.yaml_' with correct content and permissions.
2. Ran _'nfs_setup.sh setup -q'_ on primary and _'nfs_setup.sh config -q'_ on the secondary node and setup was done correctly.
   Tested above code by creating file-system and endpoint on primary node and accessing it from secondary node