### PR TITLE
EOS-12313: Re-structure Cortx-FS perfr counters format (patch for repo cortx-fs-ganesha)

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
+++ b/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
@@ -65,6 +65,14 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CAPIINC}")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-variable")
 
+# Turns on ADDB-based TDSB wrappers.
+# When this flag is disabled, KVSFS will be used the no-oop
+# wrappers.
+# When this flag is enabled, the utils module has to be
+# be compiled with this flag enabled otherwise some of
+# the function calls will be undefined.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_TSDB_ADDB")
+
 # TODO: Wrap this with a check against build type
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -fPIC")
 # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")

--- a/src/FSAL/FSAL_CORTXFS/fsal_perf.h
+++ b/src/FSAL/FSAL_CORTXFS/fsal_perf.h
@@ -1,0 +1,63 @@
+#ifndef FSAL_PERF_H_
+#define FSAL_PERF_H_
+
+#include "operation.h"
+#include <pthread.h>
+
+/**
+ * The scope for "fuser_ops" enumeration.
+ * This is the module context for all the operations
+ * being originated from this module, i.e. FSAL_CORTXFS
+ */
+extern struct modctx g_cfs_perf_mod;
+
+/**
+ * Defines a set of calls to be traced by the Operation API.
+ * This is used as operation type tag
+ */
+enum fsuser_ops {
+	FSUSER_OP_WRITE = 1,
+	// TODO: Add here for operations of future CFS FSAL handlers
+};
+
+extern pthread_key_t tls_op_key;
+
+#ifdef ENABLE_TSDB_ADDB
+
+/** Store a TSDB operation in TLS */
+#define cfs_perf_op_ini(op, mod, opcode, ...) do {	\
+	int rc;						\
+	opstack_begin(op, mod, opcode, __VA_ARGS__);	\
+	rc = pthread_setspecific(tls_op_key, op);	\
+	dassert(rc == 0);				\
+} while(0)
+
+/** Read the TLS op key and return, NULL if no key set */
+#define cfs_perf_op_get pthread_getspecific(tls_op_key)\
+
+/** Unset the TLS unconditionally */
+#define cfs_perf_op_fini(op, ...) do {			\
+	int rc;						\
+	rc = pthread_setspecific(tls_op_key, NULL);	\
+	dassert(rc == 0);				\
+	opstack_end(op, __VA_ARGS__);			\
+} while(0)
+
+/** Set a TSDB action record */
+#define cfs_perf_action(pfc_action_id, ...) \
+	opstack_action(cfs_perf_op_get, pfc_action_id, __VA_ARGS__)
+#else
+
+#define cfs_perf_op_ini(op, mod, opcode, ...)
+
+#define cfs_perf_op_get
+
+#define cfs_perf_op_fini(op, ...)
+
+#define cfs_perf_action(pfc_action_id, ...)
+
+#define cfs_perf_action(pfc_action_id, ...)
+
+#endif /* ENABLE_TSDB_ADDB */
+
+#endif /** FSAL_PERF_H_ */


### PR DESCRIPTION
# EOS-12313: Re-structure Cortx-FS perfr counters format (patch for repo cortx-fs-ganesha)

## Solution Overview
Change description:
                1) Pickup Ivan's changes from https://github.com/Seagate/cortx-posix/pull/233
                   & modify and update according to the proposed changes in EOS-12313 (https://jts.seagate.com/browse/EOS-8892)
                2) Introduce new performance counters and action maps as described in EOS-12313
                3) Update kvsfs_write2 to use the new performance counters## Checklist

- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Associated commit info from private branch EOS-12313
        commit c0b28f1790dd6918751ab598c6575f9a50a23de6
        Author: pratyush-seagate <pratyush.k.khan@seagate.com>
        Date:   Thu Sep 10 16:41:59 2020 -0600

        EOS-12313: Re-structure Cortx-FS perfr counters format (patch for repo cortx-fs-ganesha)

        List of added/modified/deleted files:
                modified:   src/FSAL/FSAL_CORTXFS/CMakeLists.txt
                new file:   src/FSAL/FSAL_CORTXFS/fsal_perf.h
                modified:   src/FSAL/FSAL_CORTXFS/handle.c

        Change description:
                1) Pickup Ivan's changes from https://github.com/Seagate/cortx-posix/pull/233
                   & modify and update according to the proposed changes in EOS-12313
                2) Introduce new performance counters and action maps as described in EOS-12313
                3) Update kvsfs_write2 to use the new performance counters

        Unit test (on LABVM):
                With ENABLE_TSDB_ADDB on, single node nfs IO (write) test and verify TSDB traces using m0addb2dump
                Compile and run UT with and without ENABLE_TSDB_ADDB
    O/P:
    * 2020-09-10-17:05:22.308899982            24001 ?               5?, ?               b?
    * 2020-09-10-17:05:22.308915847            24001 ?               5?, ?           24002?, ?               a?, ?               1?, ?               0?
    * 2020-09-10-17:05:22.317921816            24001 ?               5?, ?           24003?, ?               a?, ?               0?, ?               0?
    * 2020-09-10-17:05:22.317944557            24001 ?               5?, ?               e?
    * 2020-09-10-17:05:22.746529797            24001 ?               e?, ?               b?
    * 2020-09-10-17:05:22.746546233            24001 ?               e?, ?           24002?, ?               a?, ?               1?, ?               0?
    * 2020-09-10-17:05:22.756376965            24001 ?               e?, ?           24003?, ?               a?, ?               0?, ?               0?
    * 2020-09-10-17:05:22.756401295            24001 ?               e?, ?               e?
