### PR TITLE
EOS-13173: Fix README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/62e8043f34f642c397ab84bfbe5cba4d)](https://www.codacy.com?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Seagate/efs-ganesha&amp;utm_campaign=Badge_Grade)
 
-# KVSFS-FSAL
+# CORTXFS-FSAL
 
 NFS Ganesha backend for CORTXFS implementation.
 
@@ -9,30 +9,16 @@ NFS Ganesha FSAL API based on CORTXFS as an underlying filesystem.
 
 See also:
 
-* CORTXFS repo: https://github.com/Seagate/cortx-fs.git
-
+* Top level repo: https://github.com/Seagate/cortx-posix.git
 * NFS Ganesha repo: https://github.com/Seagate/nfs-ganesha.git
-
-* KVSFS repo: http://github.com/Seagate/cortx-fs-ganesha.git
 
 
 ### Disclaimer
 Please refer to the shared disclaimer (https://github.com/Seagate/cortx-posix#disclaimer) about this code repository.
 
-# Quick start
+### Build and Install
+For build and install related steps please refer to [CORTX-POSIX Quick Start Guide](https://github.com/Seagate/cortx-posix/blob/main/doc/CortxPosixQuickStart.md)
 
-1. Install CORTXFS packages (`libcortxfs{-devel}`).
-
-2. Download NFS Ganesha into `$PWD/../../nfs-ganesha`.
-
-3. Build & Install NFS Ganesha.
-
-4. Build & Install KVSFS-FSAL:
-
-```sh
-./scripts/build.sh reconf
-./scripts/build.sh make -j
-./scripts/build.sh reinstall
-```
-
-4. Run NFS Ganesha.
+### Contribute to CORTXFS-FSAL
+We welcome all Source Code and Documentation contributions to the CORTXFS-FSAL
+component repository. Refer to the [Contributing to CORTX-POSIX](https://github.com/Seagate/cortx-posix/blob/main/doc/ContributingToCortxPosix.md) document to submit your contributions.


### PR DESCRIPTION
https://jts.seagate.com/browse/EOS-13173

README file has reference of KVSFS, which needs to be replaced by CORTXFS.
The README file need other corrections like pointing to correct build
instructions etc.