### PR TITLE
EOS-12984: Add git commit SHA to RPMs of git repository cortx-fs-ganesha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 tags
 *.gdb_history
 TAGS
-*libfsalkvsfs.spec
-*libkvsfs_test.spec
+*.spec
+*.spec
 build-kvsfs

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,9 +37,8 @@ KVSFS_NFS_GANESHA_BUILD_DIR=${KVSFS_NFS_GANESHA_BUILD_DIR:-"$KVSFS_NFS_GANESHA_D
 KVSFS_VERSION=${CORTXFS_VERSION:-"$(cat $KVSFS_SOURCE_ROOT/VERSION)"}
 
 # Select CORTXFS Build Version.
-# Superproject: derived from cortxfs version.
-# Local: taken from git rev.
-KVSFS_BUILD_VERSION=${CORTXFS_BUILD_VERSION:-"$(git rev-parse --short HEAD)"}
+# Taken from git rev of cortx-fs-ganesha repo.
+KVSFS_BUILD_VERSION=$(git -C $KVSFS_SOURCE_ROOT rev-parse --short HEAD)
 
 
 # Optional, CORTX-UTILS source location.


### PR DESCRIPTION
## Problem Statement:
https://jts.seagate.com/browse/EOS-12984
EOS-12984: Add git commit SHA to RPMs of git repository cortx-fs-ganesha

## Problem Description:
When RPMs are built and generated via build-scripts of cortx-posix, the current path directory (PWD) fetched git commit SHA of the cortx-posix repo.
This makes it difficult to track the git build version of the individual repo.

## Solution:
The problem was solved by giving an explicit path to the git repo.
```
git -C <path_to_git_repo> rev-parse --short HEAD
```

## Tests: 
before fix:
```
cortx-fs-ganesha-test-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-fs-ganesha-debuginfo-1.0.0-7e45dd6.el7.x86_64.rpm
cortx-fs-ganesha-1.0.0-7e45dd6.el7.x86_64.rpm
```

after fix:
```
cortx-fs-ganesha-test-1.0.0-3cf744f.el7.x86_64.rpm
cortx-fs-ganesha-debuginfo-1.0.0-3cf744f.el7.x86_64.rpm
cortx-fs-ganesha-1.0.0-3cf744f.el7.x86_64.rpm

```

## Companion PRs
Seagate/cortx-utils#10
Seagate/cortx-nsal#5
https://github.com/Seagate/cortx-dsal/pull/11
Seagate/cortx-fs#7