### PR TITLE
EOS-10790 EOS-NFS: Integration with Provisioning Automated

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
+++ b/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
@@ -264,6 +264,12 @@ function cortx_nfs_init {
 	echo -e "\nNFS Initialization is complete"
 }
 
+function cortx_ganesha_restart {
+	systemctl restart nfs-ganesha || die "Failed to start NFS-Ganesha"
+	
+	echo -e "\nNFS-Ganesha restarted"
+}
+
 function cortx_nfs_config {
 	[ -n "$PROVI_SETUP" ] && get_ep
 
@@ -281,12 +287,16 @@ function cortx_nfs_config {
 	prepare_ganesha_conf
 
 	# Start NFS Ganesha Server
-	systemctl restart nfs-ganesha || die "Failed to start NFS-Ganesha"
-
-	# Create default FS
-	if [ -n "$DEFAULT_FS" ]; then
-		create_fs
+	if [ -n "$PROVI_SETUP" ]; then
+		echo "\nSkipping 'Start NFS-Ganesha Server' for provisioning"
+	else
 		systemctl restart nfs-ganesha || die "Failed to start NFS-Ganesha"
+	
+		# Create default FS
+		if [ -n "$DEFAULT_FS" ]; then
+			create_fs
+			systemctl restart nfs-ganesha || die "Failed to start NFS-Ganesha"
+		fi
 	fi
 
 	echo success > $NFS_INITIALIZED
@@ -384,6 +394,7 @@ case $cmd in
 	init    ) cortx_nfs_init;;
 	config	) cortx_nfs_config;;
 	setup	) cortx_nfs_init; cortx_nfs_config;;
+	restart ) cortx_ganesha_restart;;
 	cleanup ) cortx_nfs_cleanup;;
 	*       ) usage;;
 esac

--- a/src/FSAL/FSAL_CORTXFS/conf/setup.yaml
+++ b/src/FSAL/FSAL_CORTXFS/conf/setup.yaml
@@ -5,6 +5,9 @@ nfs_server:
         config:
                 script: /opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh
                 args: config -q
+        restart:
+                script: /opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh
+                args: restart -q
         reset:
                 script: /opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh
                 args: cleanup -q


### PR DESCRIPTION
We have requirement that nfs-ganesha service need to be start only on primary node in case of provisioning.

Modified script to add support for restart of nfs-ganesha  service.
Skipping nfs-ganesha restart for provisioning while during 'config'.
'config.sls' will call above script with restart option only in case of primary node as shown below.
e.g. 
{% if pillar['cluster'][grains['id']]['is_primary'] %}
Stage - Init server:
  cmd.run:
    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:init')
Stage - Config server:
  cmd.run:
    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:config')
Stage - Restart server:
  cmd.run:
    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:restart')
{% else %}
Stage - Config server:
  cmd.run:
    - name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:config')
{% endif %}


In case of provisioning, nfs-ganesha will be started through newly added 'restart' option by provisioning.

**UT on dev:** 

-bash-4.2$ sudo ./scripts/test.sh
[sudo] password for 754021:
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 12
Tests passed = 12
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

**Cthon On dev:**
-bash-4.2$ sudo ./cortx-fs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p fs11
sh ./runtests  -a -t /mnt/dir1/ssc-vm-c-0342.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-c-0342.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 2.33 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 3.17 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup
        1000 chmods and stats on 10 files in 154.58 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 0.1  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 691.23 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 140.6  seconds
        ./test7 ok.

./test8: symlink and readlink
        400 symlinks and readlinks on 10 files in 156.56 seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 32.11 seconds
        ./test9 ok.

Congratulations, you passed the basic tests!

**Provisioing VM**

[root@ssc-vm-c-0684 ~]# salt "*" state.apply components.nfs.config
srvnode-2:
----------
          ID: Stage - Config server
    Function: cmd.run
        Name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:config')
      Result: True
     Comment: Command "/opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh config -q" run
     Started: 23:37:14.617414
    Duration: 734.85 ms
     Changes:
              ----------
              pid:
                  25843
              retcode:
                  0
              stderr:
              stdout:
                   --

                  $ cp /etc/cortx/cortxfs.conf /etc/cortx/cortxfs.conf.25843
                  $ sed -i 13,$d /etc/cortx/cortxfs.conf
                  $ cp /etc/ganesha/ganesha.conf /etc/ganesha/ganesha.conf.25843\nSkipping 'Start NFS-Ganesha Server' for provisioning

                  NFS setup is complete

Summary for srvnode-2
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time: 734.850 ms
srvnode-1:
----------
          ID: Stage - Init server
    Function: cmd.run
        Name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:init')
      Result: True
     Comment: Command "/opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh init -q" run
     Started: 23:37:13.697119
    Duration: 9754.468 ms
     Changes:
              ----------
              pid:
                  2284
              retcode:
                  0
              stderr:
              stdout:
                   --

                  $ m0kv -l 192.168.26.74@tcp:12345:4:1 -h 192.168.26.74@tcp:12345:1:1 -p 0x7000000000000001:0x35 -f 0x7200000000000001:0x19 index drop <0x780000000000000b:1>operation rc: -2
                  drop done, rc: 0
                  Done, rc:  0

                  $ m0kv -l 192.168.26.74@tcp:12345:4:1 -h 192.168.26.74@tcp:12345:1:1 -p 0x7000000000000001:0x35 -f 0x7200000000000001:0x19 index drop <0x780000000000000b:2>operation rc: -2
                  drop done, rc: 0
                  Done, rc:  0

                  $ cp /etc/ganesha/ganesha.conf /etc/ganesha/ganesha.conf.2284NFS cleanup is complete

                  $ m0kv -l 192.168.26.74@tcp:12345:4:1 -h 192.168.26.74@tcp:12345:1:1 -p 0x7000000000000001:0x35 -f 0x7200000000000001:0x19 index create <0x780000000000000b:1>operation rc: 0
                  create done, rc: 0
                  Done, rc:  0

                  $ m0kv -l 192.168.26.74@tcp:12345:4:1 -h 192.168.26.74@tcp:12345:1:1 -p 0x7000000000000001:0x35 -f 0x7200000000000001:0x19 index create <0x780000000000000b:2>operation rc: 0
                  create done, rc: 0
                  Done, rc:  0

                  NFS Initialization is complete
----------
          ID: Stage - Config server
    Function: cmd.run
        Name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:config')
      Result: True
     Comment: Command "/opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh config -q" run
     Started: 23:37:23.452010
    Duration: 620.097 ms
     Changes:
              ----------
              pid:
                  2586
              retcode:
                  0
              stderr:
              stdout:
                   --

                  $ cp /etc/cortx/cortxfs.conf /etc/cortx/cortxfs.conf.2586
                  $ sed -i 13,$d /etc/cortx/cortxfs.conf
                  $ cp /etc/ganesha/ganesha.conf /etc/ganesha/ganesha.conf.2586\nSkipping 'Start NFS-Ganesha Server' for provisioning

                  NFS setup is complete
----------
          ID: Stage - Restart server
    Function: cmd.run
        Name: __slot__:salt:setup_conf.conf_cmd('/opt/seagate/cortx/nfs/conf/setup.yaml', 'nfs_server:restart')
      Result: True
     Comment: Command "/opt/seagate/cortx/cortx-fs-ganesha/bin/nfs_setup.sh restart -q" run
     Started: 23:37:24.072421
    Duration: 2130.453 ms
     Changes:
              ----------
              pid:
                  2645
              retcode:
                  0
              stderr:
              stdout:
                   --

                  NFS-Ganesha restarted

Summary for srvnode-1
------------
Succeeded: 3 (changed=3)
Failed:    0
------------
Total states run:     3
Total run time:  12.505 s