### PR TITLE
EOS-12812 EOS-NFS: Remove all the warnings appearing in build output

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/ds.c
+++ b/src/FSAL/FSAL_CORTXFS/ds.c
@@ -192,6 +192,7 @@ kvsfs_ds_write(struct fsal_ds_handle *const ds_pub,
 	struct kvsfs_fsal_export *kvsfs_fsal_export = 
 		container_of(ds_pub->pds->mds_fsal_export,
 			     struct kvsfs_fsal_export, export);
+	void * buf = (void *)buffer;
 	
 	fd.cfs_fd.ino = kvsfs_fh->kvsfs_handle;
 
@@ -210,7 +211,7 @@ kvsfs_ds_write(struct fsal_ds_handle *const ds_pub,
 
 	/* write the data */
 	amount_written = cfs_write(kvsfs_fsal_export->cfs_fs, &cred, &fd.cfs_fd,
-				   (void*)buffer,(const)write_length, offset);
+				   buf,(const)write_length, offset);
 	if (amount_written < 0) {
 		return posix2nfs4_error(-amount_written);
 	}

--- a/src/FSAL/FSAL_CORTXFS/ds.c
+++ b/src/FSAL/FSAL_CORTXFS/ds.c
@@ -210,7 +210,7 @@ kvsfs_ds_write(struct fsal_ds_handle *const ds_pub,
 
 	/* write the data */
 	amount_written = cfs_write(kvsfs_fsal_export->cfs_fs, &cred, &fd.cfs_fd,
-				   buffer,(const)write_length, offset);
+				   (void*)buffer,(const)write_length, offset);
 	if (amount_written < 0) {
 		return posix2nfs4_error(-amount_written);
 	}

--- a/src/FSAL/FSAL_CORTXFS/mds.c
+++ b/src/FSAL/FSAL_CORTXFS/mds.c
@@ -1137,8 +1137,9 @@ kvsfs_layoutcommit(struct fsal_obj_handle *obj_hdl,
 		container_of(obj_hdl,
 			     struct kvsfs_fsal_obj_handle,
 			     obj_handle);
-	// kvsfs_handle = myself->handle;
-	gtbl_layout_rmv_elem((const struct kvsfs_file_handle *)(myself->handle));
+	const struct kvsfs_file_handle * kvsfs_handle
+		= (const struct kvsfs_file_handle *)myself->handle;
+	gtbl_layout_rmv_elem(kvsfs_handle);
 
 	/** @todo: here, add code to actually commit the layout */
 	res->size_supplied = false;

--- a/src/FSAL/FSAL_CORTXFS/mds.c
+++ b/src/FSAL/FSAL_CORTXFS/mds.c
@@ -1138,7 +1138,7 @@ kvsfs_layoutcommit(struct fsal_obj_handle *obj_hdl,
 			     struct kvsfs_fsal_obj_handle,
 			     obj_handle);
 	// kvsfs_handle = myself->handle;
-	gtbl_layout_rmv_elem(myself->handle);
+	gtbl_layout_rmv_elem((const struct kvsfs_file_handle *)(myself->handle));
 
 	/** @todo: here, add code to actually commit the layout */
 	res->size_supplied = false;


### PR DESCRIPTION
Added explicit typecast.
Note : The function 'gtbl_layout_rmv_elem' was expecting 'const struct kvsfs_file_handle *' but was passed 'struct cfs_fh *'.  These 
 2 structure do not have common internal structure.  To remove the warning I simply performed an explicit cast for the time being as I do not know of any other way to convert to expected structure. Let me know if any change is required

UT : 
-bash-4.2$ sudo ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

**CTHON:**
-bash-4.2$ sudo ./cortx-fs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p fs1
sh ./runtests  -a -t /mnt/dir1/ssc-vm-0895.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-0895.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 4.26 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 3.22 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup
        1000 chmods and stats on 10 files in 192.64 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 1.3  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 1158.90 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 198.25 seconds
        ./test7 ok.

./test8: symlink and readlink
        400 symlinks and readlinks on 10 files in 194.7  seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 78.10 seconds
        ./test9 ok.

Congratulations, you passed the basic tests!

GENERAL TESTS: directory /mnt/dir1/ssc-vm-0895.test
if test ! -x runtests; then chmod a+x runtests; fi
cd /mnt/dir1/ssc-vm-0895.test; rm -f Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst
cp Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst /mnt/dir1/ssc-vm-0895.test

Small Compile
smcomp.time
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Tbl
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Nroff
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Large Compile
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Four simultaneous large compiles
        0.2 (0.0) real  0.1 (0.0) user  0.0 (0.0) sys

Makefile
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

General tests complete

SPECIAL TESTS: directory /mnt/dir1/ssc-vm-0895.test
cd /mnt/dir1/ssc-vm-0895.test; rm -f runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp
cp runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp /mnt/dir1/ssc-vm-0895.test

check for proper open/unlink operation
nfsjunk files before unlink:
  -rw-rw-rw- 1 root root 0 Sep 23 02:03 ./nfsvWxUMS
./nfsvWxUMS open; unlink ret = 0
nfsjunk files after unlink:
  ls: cannot access ./nfsvWxUMS: No such file or directory
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsvWxUMS: No such file or directory
test completed successfully.

check for proper open/rename operation
nfsjunk files before rename:
  -rwxrwxrwx 1 root root 0 Sep 23 02:03 ./nfsarF01B5
  -rwxrwxrwx 1 root root 0 Sep 23 02:04 ./nfsbnqAMyd
./nfsbnqAMyd open; rename ret = 0
nfsjunk files after rename:
  ls: cannot access ./nfsarF01B5: No such file or directory
  -rwxrwxrwx 1 root root 0 Sep 23 02:03 ./nfsbnqAMyd
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsarF01B5: No such file or directory
  ls: cannot access ./nfsbnqAMyd: No such file or directory
test completed successfully.

check for proper open/chmod 0 operation
testfile before chmod:
  -rw-rw-rw- 1 root root 0 Sep 23 02:04 ./nfsVtVAUw
./nfsVtVAUw open; chmod ret = 0
testfile after chmod:
  ---------- 1 root root 0 Sep 23 02:04 ./nfsVtVAUw
data compare ok
testfile after write/read:
  ---------- 1 root root 100 Sep 23 02:04 ./nfsVtVAUw
test completed successfully.

check for lost reply on non-idempotent requests
100 tries

test exclusive create.

test negative seek, you should get: read: Invalid argument
or lseek: Invalid argument
lseek: Invalid argument

test rename

test truncate
truncate succeeded
