### PR TITLE
Change write stability to FILE_SYNC

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/config/config_impl.h
+++ b/src/FSAL/FSAL_CORTXFS/config/config_impl.h
@@ -27,7 +27,7 @@
 #define CFS_CONFIG                              "/etc/cortx/cortxfs.conf"
 #define DOMAIN_NAME				"localdomain"
 #define SERIALIZE_BUFFER_DEFAULT_SIZE           2048
-#define STRIPE_UNIT                             "8192"
+#define STRIPE_UNIT                             "1048576"
 #define EXPIRE_TIME_ATTR_DEFAULT                60
 #define EXPIRE_TIME_ATTR_PNFS                   1
 #define DS_PORT                                 "2049"

--- a/src/FSAL/FSAL_CORTXFS/ds.c
+++ b/src/FSAL/FSAL_CORTXFS/ds.c
@@ -204,8 +204,6 @@ kvsfs_ds_write(struct fsal_ds_handle *const ds_pub,
 
 	/** @todo Add some debug code here about the fh to be used */
 
-	/* @todo: we could take care of parameter stability_wanted here */
-
 	/* @todo: We currently do not have any support for writeverf */
 
 	/* write the data */
@@ -217,7 +215,9 @@ kvsfs_ds_write(struct fsal_ds_handle *const ds_pub,
 
 
 	*written_length = amount_written;
-	*stability_got = stability_wanted;
+	
+	/* CORTX FS only provides file sync stability, rest are not supported */
+	*stability_got = FILE_SYNC4;
 
 	LogDebug(COMPONENT_PNFS," >> EXIT kvsfs_ds_write\n");
 	return NFS4_OK;


### PR DESCRIPTION
# EOS-12644: Degraded IOps on pNFS Export.

## Solution Overview
Client was issuing UNSTABLE writes on the data server and doing the COMMIT via the Meta Data Server.We dont have support for data commit on the MDS and dont intend to do it since CORTX FS provides FILE_SYNC stability.
Modified kvsfs_ds_write function to reflect FILE_SYNC stability on write.
Once i fixed this, i noticed that the writes were very slow.This was because the writes were issued in stripe units set to 8192.Modified stripe unit to 0x100000, so that in each write, more data is written.
               
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_


#Unit test (on LABVM):
Setup a 2 node cluster
Enabled MDS on 1 node and DS on the other node
Mounted a 4.1 export on a client and issues writes with dd

date; time dd if=/dev/urandom bs=1M count=50 of=/mnt/dir1/dd13 ;date
