### PR TITLE
EOS-11346 : Copy passed on group list in CORTXFS creds

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/ds.c
+++ b/src/FSAL/FSAL_CORTXFS/ds.c
@@ -124,8 +124,7 @@ kvsfs_ds_read(struct fsal_ds_handle *const ds_pub,
 
 	fd.cfs_fd.ino = kvsfs_fh->kvsfs_handle;
 
-	cred.uid = req_ctx->creds->caller_uid;
-	cred.gid = req_ctx->creds->caller_gid;
+	cortxfs_cred_from_op_ctx(&cred);
 
 	/* read the data */
 	amount_read = cfs_read(kvsfs_fsal_export->cfs_fs, &cred, &fd.cfs_fd,
@@ -199,8 +198,7 @@ kvsfs_ds_write(struct fsal_ds_handle *const ds_pub,
 
 	memset(writeverf, 0, NFS4_VERIFIER_SIZE);
 
-	cred.uid = req_ctx->creds->caller_uid;
-	cred.gid = req_ctx->creds->caller_gid;
+	cortxfs_cred_from_op_ctx(&cred);
 
 	/** @todo Add some debug code here about the fh to be used */
 

--- a/src/FSAL/FSAL_CORTXFS/external_storage.c
+++ b/src/FSAL/FSAL_CORTXFS/external_storage.c
@@ -185,8 +185,7 @@ int external_unlink(struct fsal_obj_handle *dir_hdl,
 	myself = container_of(dir_hdl, struct kvsfs_fsal_obj_handle,
 			      obj_handle);
 
-	cred.uid = op_ctx->creds->caller_uid;
-	cred.gid = op_ctx->creds->caller_gid;
+	cortxfs_cred_from_op_ctx(&cred);
 
 	rc = cortxfs_lookup(&cred, &myself->handle->kvsfs_handle,
 			    (char *)name, &object);

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -244,7 +244,7 @@ static bool kvsfs_fh_is_open(struct kvsfs_fsal_obj_handle *obj)
 /*****************************************************************************/
 /* Copy FSAL attrs into CORTXFS attrs
  */
-static inline void cortxfs_cred_from_op_ctx(cfs_cred_t *out)
+inline void cortxfs_cred_from_op_ctx(cfs_cred_t *out)
 {
 	int i;
 
@@ -252,8 +252,9 @@ static inline void cortxfs_cred_from_op_ctx(cfs_cred_t *out)
 
 	out->uid = op_ctx->creds->caller_uid;
 	out->gid = op_ctx->creds->caller_gid;
-	out->total_grps = op_ctx->creds->caller_glen;
-	for (i=0; i<op_ctx->creds->caller_glen; i++) {
+	out->total_grps = (op_ctx->creds->caller_glen <= CORTXFS_CRED_GRPS) ? \
+			  op_ctx->creds->caller_glen : CORTXFS_CRED_GRPS;
+	for (i = 0; i < out->total_grps; i++) {
 		out->grp_list[i] = op_ctx->creds->caller_garray[i];
 	}
 }

--- a/src/FSAL/FSAL_CORTXFS/kvsfs_methods.h
+++ b/src/FSAL/FSAL_CORTXFS/kvsfs_methods.h
@@ -7,14 +7,6 @@
 #include <gsh_list.h>
 #include <fsal_types.h>
 
-/******************************************************************************/
-/* Common helpers */
-
-#define CFS_CRED_INIT_FROM_OP {					\
-	.uid = op_ctx->creds->caller_uid,			\
-	.gid = op_ctx->creds->caller_gid,			\
-	.total_grps = op_ctx->creds->caller_glen,		\
-}
 
 /******************************************************************************/
 

--- a/src/FSAL/FSAL_CORTXFS/kvsfs_methods.h
+++ b/src/FSAL/FSAL_CORTXFS/kvsfs_methods.h
@@ -10,18 +10,10 @@
 /******************************************************************************/
 /* Common helpers */
 
-static inline void cortxfs_cred_from_op_ctx(cfs_cred_t *out)
-{
-	assert(out);
-	assert(op_ctx);
-
-	out->uid = op_ctx->creds->caller_uid;
-	out->gid = op_ctx->creds->caller_gid;
-}
-
-#define CFS_CRED_INIT_FROM_OP {			\
-	.uid = op_ctx->creds->caller_uid,	\
-	.gid = op_ctx->creds->caller_gid,	\
+#define CFS_CRED_INIT_FROM_OP {					\
+	.uid = op_ctx->creds->caller_uid,			\
+	.gid = op_ctx->creds->caller_gid,			\
+	.total_grps = op_ctx->creds->caller_glen,		\
 }
 
 /******************************************************************************/


### PR DESCRIPTION
# CORTXFS_FSAL Change Summary

## Problem Statement

_[EOS-11346](https://jts.seagate.com/browse/EOS-11346):_
_CORTXFS FSAL incorrectly handling multiple groups_

## Problem Description

_CORTXFS FSAL code do not consider the passed on group list via NFS RPC_

## Solution Overview

_Added code to parse the group list and store it in CORTXFS creds_
NFS RPC sends a list of groups, the user is part of. Need to copy
this group list into CORTXFS creds structure for further use.

### Companion PR
https://github.com/Seagate/cortx-fs/pull/14

## Unit Test Cases
_cthon test is passing Basic, General test cases_

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _As mentioned related test cases are passing_