### PR TITLE
EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo cortx-fs-ganesha)

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
+++ b/src/FSAL/FSAL_CORTXFS/CMakeLists.txt
@@ -65,6 +65,13 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${CAPIINC}")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unused-variable")
 
+# Turns on ADDB-based TDSB wrappers.
+# When this flag is disabled, perfc TSDB code will be turned off.
+# When this flag is enabled, the utils module has to be
+# compiled with this flag enabled otherwise some of
+# the function calls will be undefined.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DENABLE_TSDB_ADDB")
+
 # TODO: Wrap this with a check against build type
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g3 -fPIC")
 # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -66,11 +66,42 @@
 #include <cortxfs_fh.h>
 #include <nfs_exports.h> /* EXPORT_OPTION_DISABLE_ACL */
 #include <debug.h>	/* dassert */
+#include "operation.h"
 
 #include <../FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_int.h>
 #include <../FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_hash.h>
 
 /******************************************************************************/
+
+/**
+ * CORTXFS PERF ENH:
+ * Adding support for read2 
+ * TODO: Similar change will be needed for rest of the FSAL handlers
+ **/
+
+typedef void (*cortxfs_fsal_read)(struct fsal_obj_handle *obj_hdl,
+			bool bypass,
+			fsal_async_cb done_cb,
+			struct fsal_io_arg *read_arg,
+			void *caller_arg);
+
+static void kvsfs_read2(struct fsal_obj_handle *obj_hdl,
+			bool bypass,
+			fsal_async_cb done_cb,
+			struct fsal_io_arg *read_arg,
+			void *caller_arg);
+
+static void kvsfs_perf_op_read2(struct fsal_obj_handle *obj_hdl,
+			 bool bypass,
+			 fsal_async_cb done_cb,
+			 struct fsal_io_arg *read_arg,
+			 void *caller_arg);
+
+cortxfs_fsal_read cortxfs_fsal_reads[2] = {
+	kvsfs_read2,
+	kvsfs_perf_op_read2
+};
+
 /* Internal data types */
 
 /** KVSFS version of a file state object.
@@ -2814,6 +2845,11 @@ static void kvsfs_read2(struct fsal_obj_handle *obj_hdl,
 		(unsigned long long) read_arg->iov_count,
 		(unsigned long long) read_arg->iov[0].iov_len);
 
+	perfc_trace_state(PES_GEN_INIT);
+	perfc_trace_attr(PEA_R_OFFSET, read_arg->offset);
+	perfc_trace_attr(PEA_R_IOVC, read_arg->iov_count);
+	perfc_trace_attr(PEA_R_IOVL, read_arg->iov[0].iov_len);
+
 	/* NFS Ganesha uses only a single buffer so far. */
 	assert(read_arg->iov_count == 1);
 
@@ -2841,8 +2877,28 @@ static void kvsfs_read2(struct fsal_obj_handle *obj_hdl,
 
 	result = fsalstat(ERR_FSAL_NO_ERROR, 0);
 out:
+	perfc_trace_attr(PEA_R_RES_MAJ, result.major);
+	perfc_trace_attr(PEA_R_RES_MIN, result.minor);
+	perfc_trace_state(PES_GEN_FINI);
+
 	T_EXIT0(result.major);
 	done_cb(obj_hdl, result, read_arg, caller_arg);
+}
+
+/**
+ * This is just a wrapper of kvsfs_read2 with added support for TSDB
+ * for monitoring performance
+ */
+static void kvsfs_perf_op_read2(struct fsal_obj_handle *obj_hdl,
+			 bool bypass,
+			 fsal_async_cb done_cb,
+			 struct fsal_io_arg *read_arg,
+			 void *caller_arg)
+{
+	uint64_t myopid = perf_id_gen();
+	perfc_tls_ini(TSDB_MOD_FSUSER, myopid, PFT_FSAL_READ);
+	kvsfs_read2(obj_hdl, bypass, done_cb, read_arg, caller_arg);
+	perfc_tls_fini();
 }
 
 /******************************************************************************/
@@ -3037,9 +3093,20 @@ static fsal_status_t kvsfs_commit2(struct fsal_obj_handle *obj_hdl,
 }
 
 /******************************************************************************/
+
 void kvsfs_handle_ops_init(struct fsal_obj_ops *ops)
 {
+	uint8_t enable_mon = 0;
+	int rc; 
+
+	rc = pthread_key_create(&perfc_tls_key, NULL);
+	dassert(rc == 0);
+
 	fsal_default_obj_ops_init(ops);
+
+#ifdef ENABLE_TSDB_ADDB
+	enable_mon = 1;
+#endif /* ENABLE_TSDB_ADDB */
 
 	// Namespace
 	ops->release = release;
@@ -3069,7 +3136,7 @@ void kvsfs_handle_ops_init(struct fsal_obj_ops *ops)
 	ops->reopen2 = kvsfs_reopen2;
 
 	// File IO
-	ops->read2 = kvsfs_read2;
+	ops->read2 = cortxfs_fsal_reads[enable_mon];
 	ops->write2 = kvsfs_write2;
 	ops->commit2 = kvsfs_commit2;
 


### PR DESCRIPTION
# EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo cortx-fs-ganesha)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## Commit Message
            commit 4a32ddb2875ee5ec856995d79968197c922d2607
            Author: pratyush-seagate <pratyush.k.khan@seagate.com>
            Date:   Thu Sep 24 03:16:05 2020 -0600

            EOS-8896: NFS ADDB: NFS-only tracepoints for READ (repo cortx-fs-ganesha)
            List of modified files:
                    modified:   src/FSAL/FSAL_CORTXFS/CMakeLists.txt
                    modified:   src/FSAL/FSAL_CORTXFS/handle.c
            Change description:
                    Add new performance counters and integrate them further with other modules using newly added APIs
                    Integrate changes from EOS-13398 --> EOS-12314 --> EOS-8896
                    Add perf counters in the fsal read handler
                    Addb APIs integration for read path
            Unit test:
                    Compilation with and without ENABLE_TSDB_ADDB flag
                    Addb unit test while integrated with read handler
                    Regular UTs (both with and without ENABLE_TSDB_ADDB flag)
            addb dump o/p from read handler after integration:
            * 2020-09-29-17:27:47.484505618            210ab ?               1?, ?               1?, ?            5035?, ?               1?
            * 2020-09-29-17:27:47.484506598            210cd ?               1?, ?               2?, ?            5035?, ?               5?, ?               0?
            * 2020-09-29-17:27:47.484507284            210cd ?               1?, ?               2?, ?            5035?, ?               6?, ?               1?
            * 2020-09-29-17:27:47.484508075            210cd ?               1?, ?               2?, ?            5035?, ?               7?, ?            1000?
            * 2020-09-29-17:27:47.484524037            210ab ?               4?, ?               1?, ?            5036?, ?               1?
            * 2020-09-29-17:27:47.484524850            210ef ?               4?, ?               3?, ?               6?, ?            5036?, ?            5035?
            * 2020-09-29-17:27:47.484525701            210cd ?               4?, ?               2?, ?            5036?, ?               a?, ?            1000?
            * 2020-09-29-17:27:47.484526538            210cd ?               4?, ?               2?, ?            5036?, ?               b?, ?               0?
            * 2020-09-29-17:27:47.484528239            210ab ?               2?, ?               1?, ?            5037?, ?               1?
            * 2020-09-29-17:27:47.484528994            210ef ?               2?, ?               3?, ?              10?, ?            5037?, ?            5035?
            * 2020-09-29-17:27:47.484529869            210cd ?               2?, ?               2?, ?            5037?, ?              10?, ?              12?
            * 2020-09-29-17:27:47.484531526            210cd ?               2?, ?               2?, ?            5037?, ?              11?, ?               0?
            * 2020-09-29-17:27:47.484532228            210ab ?               2?, ?               1?, ?            5037?, ?               2?
            * 2020-09-29-17:27:47.484533046            210ab ?               3?, ?               1?, ?            5038?, ?               1?
            * 2020-09-29-17:27:47.484533789            210ef ?               3?, ?               3?, ?              10?, ?            5038?, ?            5035?
            * 2020-09-29-17:27:47.484534649            210cd ?               3?, ?               2?, ?            5038?, ?              17?, ?              12?
            * 2020-09-29-17:27:47.484535507            210cd ?               3?, ?               2?, ?            5038?, ?              18?, ?               0?
            * 2020-09-29-17:27:47.487947750            210cd ?               3?, ?               2?, ?            5038?, ?              19?, ?               0?
            * 2020-09-29-17:27:47.487948775            210ab ?               3?, ?               1?, ?            5038?, ?               2?
