### PR TITLE
restructure pNFS parameter parsing

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
+++ b/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
@@ -24,6 +24,7 @@ DEFAULT_EXPORT_OPTION+="clients=*,Squash=no_root_squash,access_type=RW,protocols
 # Enable/Disable pNFS
 pNFS_ENABLED=false
 pNFS_DATA_SERVER=$(hostname -i)
+pNFS_ROLE="PNFS_DISABLED"
 
 function die {
 	log "error: $*"
@@ -99,6 +100,35 @@ function motr_lib_init {
 	[ $? -ne 0 ] && die "Failed to Initialise motr_lib fs_meta index"
 }
 
+function prepare_pnfs_conf {
+IFS=',' read -ra ADDR <<< "$pNFS_DATA_SERVER"
+count=0
+rm -rf /etc/ganesha/pNFS.conf
+echo "[pNFS]" >> /etc/ganesha/pNFS.conf
+echo "  pNFS_Role = $pNFS_ROLE" >> /etc/ganesha/pNFS.conf
+
+if [ "$pNFS_ROLE" != "PNFS_DISABLED" ]; then
+pNFS_ENABLED=true;
+echo "pNFS_ENABLED is $pNFS_ENABLED"
+fi
+
+if [ "$pNFS_ROLE" == "MDS" ] || [ "$pNFS_ROLE" == "BOTH" ]; then
+for i in "${ADDR[@]}"; do
+let "count= count+1"
+echo "  DS$count = $i:2049" >> /etc/ganesha/pNFS.conf
+done
+
+if [ "$pNFS_ROLE" == "BOTH" ]; then
+let "count= count+1"
+echo "  DS$count = $(hostname -i):2049" >> /etc/ganesha/pNFS.conf
+fi
+echo "  NumDataServers = $count" >> /etc/ganesha/pNFS.conf
+
+echo "  MDS = $(hostname -i)" >> /etc/ganesha/pNFS.conf
+
+fi
+}
+
 function prepare_cortx_fs_conf {
 	log "Initializing Cortx-FS..."
 
@@ -162,15 +192,6 @@ EXPORT {
 		Name  = CORTX-FS;
 		cortxfs_config = $CORTXFS_CONF;
 
-		PNFS {
-			Stripe_Unit = 8192;
-			pnfs_enabled = $pNFS_ENABLED;
-			Nb_Dataserver = 1;
-			DS1 {
-				DS_Addr = $pNFS_DATA_SERVER;
-				DS_Port = 2049;
-			}
-		}
 	}
 
 	# Allowed security types for this export
@@ -273,6 +294,9 @@ function cortx_nfs_config {
 
 	# Check prerequisites
 	check_prerequisites
+
+	# Prepare pNFS.conf
+	prepare_pnfs_conf
 
 	# Prepare cortxfs.conf
 	prepare_cortx_fs_conf
@@ -392,8 +416,8 @@ Options:
   -p Prompt
   -q To perform Setup on Provisioner VM
   -d To create FS
-  -r pNFS Enabled
-  -D pNFS Data-Server IP Addr 
+  -r pNFS Role {MDS|DS|BOTH}.If pNFS should be disabled do not specify -r option
+  -D pNFS Data-Server IP Addr for MDS and BOTH options {IPADDR1,IPADDR2...IPADDRN} 
 
 Default values used for Index creation on Dev env are-
    Profile:               <0x7000000000000001:0>
@@ -419,7 +443,7 @@ while [ ! -z $1 ]; do
 	case "$1" in
 		-h ) usage;;
 		-f ) force=1;;
-		-r ) pNFS_ENABLED=true;;
+		-r ) pNFS_ROLE=$2; shift 1;;
 		-D ) pNFS_DATA_SERVER=$2; shift 1;;
 		-p ) prompt=1;;
 		-q ) PROVI_SETUP=1;;

--- a/src/FSAL/FSAL_CORTXFS/config/config_impl.c
+++ b/src/FSAL/FSAL_CORTXFS/config/config_impl.c
@@ -90,58 +90,6 @@ static void append_data(struct serialized_buffer *buffer, char *data, int len)
 	return;
 }
 
-void json_to_dataserver_block(struct json_object *obj, struct ds_block *block)
-{
-	struct json_object *json_obj = NULL;
-	const char *str = NULL;
-
-	json_object_object_get_ex(obj, "data_server", &json_obj);
-	if (json_obj == NULL) {
-		/* This is a workaround till we restructure
- 		 * the parsing of pNFS block.Assign a dummy
- 		 * IP address, so that file system export does
- 		 * not fail
- 		 */
-		str = "127.0.0.1";	
-	} else {
-		str = json_object_get_string(json_obj);
-	}
-	str256_from_cstr(block->ds_addr, str, strlen(str));
-
-	// Assign port number.
-	str256_from_cstr(block->ds_port, DS_PORT, strlen(DS_PORT));
-	return;
-}
-
-/* Creates pnfs_block structures from json */
-void json_to_pnfs_block(struct json_object *obj, struct pnfs_block *block)
-{
-	struct json_object *json_obj = NULL;
-	const char *str = NULL;
-
-	str256_from_cstr(block->stripe_unit, STRIPE_UNIT, strlen(STRIPE_UNIT));
-
-	json_object_object_get_ex(obj, "pnfs_enabled", &json_obj);
-	if (json_obj == NULL) {
-		str = "false";
-	} else {
-		str = json_object_get_string(json_obj);
-	}
-	str256_from_cstr(block->pnfs_enabled, str, strlen(str));
-
-	/* Due to parsing limitations in nfs ganesha conf,
- 	 * there is support for only 1 data server currently.
- 	 * This is temporary and PNFS config parsing
- 	 * will be restructured and moved out of the export block
- 	 */
-
-	str = "1";
-	str256_from_cstr(block->ds_count, str, strlen(str));
-
-	json_to_dataserver_block(obj, &block->ds_block);
-	return;
-}
-
 /*creates export_fsal_block structure from json */
 void json_to_export_fsal_block(struct json_object *obj,
 			       struct export_fsal_block *block)
@@ -149,8 +97,6 @@ void json_to_export_fsal_block(struct json_object *obj,
 	str256_from_cstr(block->name, FSAL_NAME, strlen(FSAL_NAME));
 	str256_from_cstr(block->cfs_config, CFS_CONFIG, strlen(CFS_CONFIG));
 
-	// Fill the pNFS block.
-	json_to_pnfs_block(obj, &block->pnfs_block);
 	return;
 }
 
@@ -384,49 +330,6 @@ static void client_to_buffer(struct client_block *block,
 	memset(str, '\0', sizeof(str));
 }
 
-static void pnfs_to_buffer(struct pnfs_block *block,
-			   struct serialized_buffer *buffer)
-{
-	char str[256];
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\tPNFS {\n");
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\tStripe_Unit = %s;\n", block->stripe_unit.s_str);
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\tpnfs_enabled = %s;\n", block->pnfs_enabled.s_str);
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\tNb_Dataserver = %s;\n", block->ds_count.s_str);
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\tDS1 {\n");
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\t\tDS_Addr = %s;\n", block->ds_block.ds_addr.s_str);
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\t\tDS_Port = %s;\n", block->ds_block.ds_port.s_str);
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t\t}\n");
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-
-	snprintf(str, sizeof(str), "\t\t}\n");
-	append_data(buffer, str, strlen(str));
-	memset(str, '\0', sizeof(str));
-}
-
 /* serializes export_block structure to buffer */
 static void export_to_buffer(struct export_block *block,
 			     struct serialized_buffer *buffer)
@@ -466,8 +369,6 @@ static void export_to_buffer(struct export_block *block,
 		block->fsal_block.cfs_config.s_str);
 	append_data(buffer, str, strlen(str));
 	memset(str, '\0', sizeof(str));
-
-	pnfs_to_buffer(&block->fsal_block.pnfs_block, buffer);
 
 	snprintf(str, sizeof(str), "\t}\n");
 	append_data(buffer, str, strlen(str));

--- a/src/FSAL/FSAL_CORTXFS/config/config_impl.h
+++ b/src/FSAL/FSAL_CORTXFS/config/config_impl.h
@@ -27,34 +27,17 @@
 #define CFS_CONFIG                              "/etc/cortx/cortxfs.conf"
 #define DOMAIN_NAME				"localdomain"
 #define SERIALIZE_BUFFER_DEFAULT_SIZE           2048
-#define STRIPE_UNIT                             "1048576"
 #define EXPIRE_TIME_ATTR_DEFAULT                60
 #define EXPIRE_TIME_ATTR_PNFS                   1
-#define DS_PORT                                 "2049"
-
-struct ds_block {
-	str256_t ds_addr;
-	str256_t ds_port;
-};
-
-struct pnfs_block {
-	str256_t stripe_unit;
-	str256_t pnfs_enabled;
-	str256_t ds_count;
-	struct ds_block ds_block;
-};
 
 struct export_fsal_block {
 	str256_t name;
 	str256_t cfs_config;
-	struct pnfs_block pnfs_block;
 };
 
 /* Default config block */
 struct kvsfs_block {
 	str256_t fsal_shared_library;
-	str256_t pnfs_mds;
-	str256_t pnfs_ds;
 };
 
 struct fsal_block {

--- a/src/FSAL/FSAL_CORTXFS/fsal_internal.h
+++ b/src/FSAL/FSAL_CORTXFS/fsal_internal.h
@@ -4,8 +4,15 @@
 #include "fsal.h" /* attributes */
 #include "kvsfs_methods.h"
 
+enum cortxfs_pNFS_server_role {
+        CORTXFS_PNFS_DISABLED = 0,
+        CORTXFS_PNFS_DS,
+        CORTXFS_PNFS_MDS,
+        CORTXFS_PNFS_BOTH
+};
+
 // forward declaration
-struct kvsfs_pnfs_mds_ctx;
+struct cortxfs_pnfs_mds_ctx;
 
 /* KVSFS FSAL module private storage
  */
@@ -15,7 +22,7 @@ struct kvsfs_fsal_module {
 	struct fsal_staticfsinfo_t fs_info;
 	struct fsal_obj_ops handle_ops;
 	/* pNFS related KVSFS FSAL's global config */
-	struct kvsfs_pnfs_mds_ctx *mds_ctx;
+	struct cortxfs_pnfs_mds_ctx *mds_ctx;
 };
 /** KVSFS-related data for a file state object. */
 struct kvsfs_file_state {
@@ -31,6 +38,8 @@ fsal_status_t kvsfs_create_export(struct fsal_module *fsal_hdl,
 				const struct fsal_up_vector *up_ops);
 
 void kvsfs_handle_ops_init(struct fsal_obj_ops *ops);
+uint8_t get_pnfs_role(struct kvsfs_fsal_module *kvsfs);
+
 struct kvsfs_fsal_obj_handle {
 	/* Base Handle */
 	struct fsal_obj_handle obj_handle;
@@ -87,11 +96,10 @@ extern struct fsal_staticfsinfo_t global_fs_info;
 /* KVSFS methods for pnfs
  */
 
-int kvsfs_pmds_ini(struct kvsfs_fsal_module *kvsfs,
+int cortxfs_pmds_ini(struct kvsfs_fsal_module *kvsfs,
 		   const struct config_item *kvsfs_params);
-int kvsfs_pmds_fini(struct kvsfs_fsal_module *kvsfs);
-int kvsfs_pmds_update_exp(struct kvsfs_fsal_module *kvsfs,
-			  const struct kvsfs_fsal_export *exp_config);
+int cortxfs_pmds_fini(struct kvsfs_fsal_module *kvsfs);
+
 nfsstat4 kvsfs_getdeviceinfo(struct fsal_module *fsal_hdl,
 			      XDR *da_addr_body,
 			      const layouttype4 type,

--- a/src/FSAL/FSAL_CORTXFS/kvsfs_methods.h
+++ b/src/FSAL/FSAL_CORTXFS/kvsfs_methods.h
@@ -9,23 +9,6 @@
 
 
 /******************************************************************************/
-
-/* this needs to be refactored to put ipport inside sockaddr_in */
-struct kvsfs_pnfs_ds_parameter {
-	struct glist_head ds_list;
-	sockaddr_t ipaddr;
-	unsigned short ipport;
-	unsigned int id;
-};
-
-#define KVSFS_NB_DS 4
-struct kvsfs_exp_pnfs_parameter {
-	unsigned int stripe_unit;
-	bool pnfs_enabled;
-	unsigned int nb_ds;
-	struct kvsfs_pnfs_ds_parameter ds_array[KVSFS_NB_DS];
-};
-
 struct kvsfs_fsal_index_context;
 
 /* Wrapper for a File Handle object. */
@@ -51,10 +34,10 @@ struct kvsfs_fsal_export {
 
 	/** Export config. */
 	char *cfs_config;
-	// TODO: The following members will be moved to global FSAL
+
+	/* PNFS, MDS and DS need be enabled on FSAL export */	
 	bool pnfs_ds_enabled;
 	bool pnfs_mds_enabled;
-	struct kvsfs_exp_pnfs_parameter pnfs_param;
 };
 
 /** Get export's Root handle by path. */


### PR DESCRIPTION
# EOS-13266: Restructure pNFS configuration parameters parsing

## Solution Overview
pNFS configuration parameters are currently a part of FSAL export block.These should not be on a per export basis and should be moved to a global scope.
This solution provides the following
1)Move the pNFS configuration to a separate pNFS.conf
3)Parse the pNFS.conf
4)Clean up existing pNFS parsing code
               
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_


#Unit test (on LABVM):
Setup a 2 node cluster
Enabled MDS on 1 node and DS on the other node
Mounted a 4.1 export on a client and issues writes/read with dd
Using tshark verified that the writes/reads are issued by the client to appropriate data servers