### PR TITLE
EOS-13986: NFS ADDB tracepoints for WRITE operation (cortx-fs-ganesha changes)

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -144,13 +144,13 @@ typedef void (*cortxfs_fsal_write)(struct fsal_obj_handle *obj_hdl,
 			struct fsal_io_arg *write_arg,
 			void *caller_arg);
 
-static void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
+static inline void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
 			bool bypass,
 			fsal_async_cb done_cb,
 			struct fsal_io_arg *write_arg,
 			void *caller_arg);
 
-static void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
+static inline void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
 			 bool bypass,
 			 fsal_async_cb done_cb,
 			 struct fsal_io_arg *write_arg,

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -3031,7 +3031,7 @@ static void kvsfs_perf_op_read2(struct fsal_obj_handle *obj_hdl,
  * This is just a wrapper of kvsfs_write2 with added support for TSDB
  * for monitoring performance
  */
-static void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
+static inline void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
 			 bool bypass,
 			 fsal_async_cb done_cb,
 			 struct fsal_io_arg *write_arg,
@@ -3136,7 +3136,7 @@ out:
  * @param[in,out] write_arg	Info about write, passed back in callback
  * @param[in,out] caller_arg	Opaque arg from the caller for callback
  */
-static void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
+static inline void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
 			 bool bypass,
 			 fsal_async_cb done_cb,
 			 struct fsal_io_arg *write_arg,

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -132,6 +132,35 @@ cortxfs_fsal_setattr cortxfs_fsal_setattrs[2] = {
     kvsfs_setattrs,
     kvsfs_perf_op_setattrs
 };
+
+/**
+ * CORTXFS PERF ENH:
+ * Adding support for write2 
+ **/
+
+typedef void (*cortxfs_fsal_write)(struct fsal_obj_handle *obj_hdl,
+			bool bypass,
+			fsal_async_cb done_cb,
+			struct fsal_io_arg *write_arg,
+			void *caller_arg);
+
+static void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
+			bool bypass,
+			fsal_async_cb done_cb,
+			struct fsal_io_arg *write_arg,
+			void *caller_arg);
+
+static void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
+			 bool bypass,
+			 fsal_async_cb done_cb,
+			 struct fsal_io_arg *write_arg,
+			 void *caller_arg);
+
+cortxfs_fsal_write cortxfs_fsal_writes[2] = {
+	kvsfs_write2,
+	kvsfs_perf_op_write2
+};
+
 /* Internal data types */
 
 /** KVSFS version of a file state object.
@@ -2998,6 +3027,22 @@ static void kvsfs_perf_op_read2(struct fsal_obj_handle *obj_hdl,
 	perfc_tls_fini();
 }
 
+/**
+ * This is just a wrapper of kvsfs_write2 with added support for TSDB
+ * for monitoring performance
+ */
+static void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
+			 bool bypass,
+			 fsal_async_cb done_cb,
+			 struct fsal_io_arg *write_arg,
+			 void *caller_arg)
+{
+	uint64_t myopid = perf_id_gen();
+	perfc_tls_ini(TSDB_MOD_FSUSER, myopid, PFT_FSAL_WRITE);
+	kvsfs_write2(obj_hdl, bypass, done_cb, write_arg, caller_arg);
+	perfc_tls_fini();
+}
+
 /******************************************************************************/
 /* TODO:CORTXFS: a dummy implementation of FSYNC call */
 static int cfs_fsync(struct cfs_fs *cfs_fs, cfs_cred_t *cred, cfs_ino_t *ino)
@@ -3132,6 +3177,11 @@ static void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
 		(unsigned long long) write_arg->iov_count,
 		(unsigned long long) write_arg->iov[0].iov_len);
 
+	perfc_trace_state(PES_GEN_INIT);
+	perfc_trace_attr(PEA_R_OFFSET, write_arg->offset);
+	perfc_trace_attr(PEA_R_IOVC, write_arg->iov_count);
+	perfc_trace_attr(PEA_R_IOVL, write_arg->iov[0].iov_len);
+
 	/* So far, NFS Ganesha always sends only a single buffer in a FSAL.
 	 * We can use this information for keeping write2 implementation
 	 * simple, i.e. there is no need to implement pwritev-like call
@@ -3172,6 +3222,10 @@ static void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
 
 	result = fsalstat(ERR_FSAL_NO_ERROR, 0);
 out:
+	perfc_trace_attr(PEA_R_RES_MAJ, result.major);
+	perfc_trace_attr(PEA_R_RES_MIN, result.minor);
+	perfc_trace_state(PES_GEN_FINI);
+
 	T_EXIT0(result.major);
 	PTHREAD_RWLOCK_unlock(&obj_hdl->obj_lock);
 	done_cb(obj_hdl, result, write_arg, caller_arg);
@@ -3236,7 +3290,7 @@ void kvsfs_handle_ops_init(struct fsal_obj_ops *ops)
 
 	// File IO
 	ops->read2 = cortxfs_fsal_reads[enable_mon];
-	ops->write2 = kvsfs_write2;
+	ops->write2 = cortxfs_fsal_writes[enable_mon];
 	ops->commit2 = kvsfs_commit2;
 
 	/* ops->lock_op2 is not implemented because this FSAl relies on


### PR DESCRIPTION
# cortx-fs-ganesha Change Summary

## Problem Statement
_[EOS-13986](https://jts.seagate.com/browse/EOS-13986):_
_NFS ADDB tracepoints for WRITE operation_

## Problem Description
_Add ADDB tracepoints for WRITE operation_

## Solution Overview
_Reviewed changes made to READ operation and create similar for WRITE_

## Unit Test Cases
_Full build, executed testing scripts_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [ ] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [X] **Sanity Testing:** _Done as mentioned in testing above_
- [ ] **Documentation:** _TBD_