### PR TITLE
EOS-14314:Cleanup unused pNFS parameters from nfs_setup script

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
+++ b/src/FSAL/FSAL_CORTXFS/conf/nfs_setup.sh
@@ -49,8 +49,7 @@ function create_fs {
 	[ $? -ne 0 ] && die "Failed to create $DEFAULT_FS"
 	
 	# Add pNFS options.
-	DEFAULT_EXPORT_OPTION+="pnfs_enabled=$pNFS_ENABLED,"
-	DEFAULT_EXPORT_OPTION+="data_server=$pNFS_DATA_SERVER"
+	DEFAULT_EXPORT_OPTION+="pnfs_enabled=$pNFS_ENABLED"
 
 	echo -e "\nExporting default file system $DEFAULT_FS $DEFAULT_EXPORT_OPTION ..."
 	run $CORTXFS_FS_CLI endpoint create $DEFAULT_FS $DEFAULT_EXPORT_OPTION
@@ -344,16 +343,7 @@ EXPORT {
                 Name  = CORTX-FS;
                 cortxfs_config = $CORTXFS_CONF;
 
-                PNFS {
-                        Stripe_Unit = 8192;
-                        pnfs_enabled = $pNFS_ENABLED;
-                        Nb_Dataserver = 1;
-                        DS1 {
-                                DS_Addr = $pNFS_DATA_SERVER;
-                                DS_Port = 2049;
-                        }
-                }
-        }
+	}
 
         # Allowed security types for this export
         SecType = sys;
@@ -373,7 +363,7 @@ EXPORT {
                 # Restrict the protocols that may use this export.  This cannot allow
                 # access that is denied in NFS_CORE_PARAM.
                 protocols = 4;
-        }
+	}
 }
 EOM
 	echo -e "\nStarting NFS Ganesha"


### PR DESCRIPTION
# EOS-14314 : Cleanup unused pNFS parameters from nfs_setup script.

## Solution Overview
Change description:
1)Data server parameter continued to get parsed when endpoints are created using nfs_setup script.
This parameter is unused in the code and can be removed.
2) In the nfs_setup restart path, 
 **nfs_setup restart**
the ganesha.conf that is created has the pNFS block printed.This is removed.

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** Single node changes are unit tested_

##  Unit test (on LABVM):
1)Compiled the code and reinstalled the RPM
2)Ran the nfs_setup script with the following parameters
**nfs_setup setup -d fs3**
## Without the fix, following output is seen. 
**Data server parameter is seen in cortxfscli output**

$ /usr/bin/cortxfscli fs create cortxfsCreated

Exporting default file system cortxfs proto=nfs,secType=sys,Filesystem_id=192.1,client=1,clients=*,Squash=no_root_squash,access_type=RW,protocols=4,pnfs_enabled=false, ***_data_server=10.230.241.103__*** ...

$ /usr/bin/cortxfscli endpoint create cortxfs proto=nfs,secType=sys,Filesystem_id=192.1,client=1,clients=*,Squash=no_root_squash,access_type=RW,protocols=4,pnfs_enabled=false,data_server=10.230.241.103Using embedded validation rules
Created

## With the fix, following output is seen
**No data server parameter in cortxfscli output**

_$ /usr/bin/cortxfscli fs create fs3Created

Exporting default file system fs3 proto=nfs,secType=sys,Filesystem_id=192.1,client=1,clients=*,Squash=no_root_squash,access_type=RW,protocols=4,pnfs_enabled=false ...

$ /usr/bin/cortxfscli endpoint create fs3 proto=nfs,secType=sys,Filesystem_id=192.1,client=1,clients=*,Squash=no_root_squash,access_type=RW,protocols=4,pnfs_enabled=falseUsing embedded validation rules
Created_
