### PR TITLE
EOS-13992: ADDB tracepoints for directory operations

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -665,7 +665,7 @@ static inline fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
 		 *  access checks using ACLs are implemented.
 		 */
 
-		perfc_trace_attr(PEA_OTHER_FUNC_CALL, 1);
+		perfc_trace_attr(PEA_TIME_ATTR_START_OTHER_FUNC, 1);
 
 		/* Try to get ACL of the parent directory, and set them
                    on the child directory. */
@@ -695,8 +695,7 @@ static inline fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
 				 goto free_attrs;
 		}
 
-		perfc_trace_attr(PEA_OTHER_FUNC_END, 1);
-
+		perfc_trace_attr(PEA_TIME_ATTR_END_OTHER_FUNC, 1);
 	} /* if (kvsfs_is_acl_enabled()) */
 
 free_attrs:

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -75,7 +75,7 @@
 
 /**
  * CORTXFS PERF ENH:
- * Adding support for read2 
+ * Adding support for read2, mkdir, readdir, lookup 
  * TODO: Similar change will be needed for rest of the FSAL handlers
  **/
 
@@ -92,51 +92,52 @@ static void kvsfs_read2(struct fsal_obj_handle *obj_hdl,
 			void *caller_arg);
 
 static void kvsfs_perf_op_read2(struct fsal_obj_handle *obj_hdl,
-			 bool bypass,
-			 fsal_async_cb done_cb,
-			 struct fsal_io_arg *read_arg,
-			 void *caller_arg);
+			bool bypass,
+			fsal_async_cb done_cb,
+			struct fsal_io_arg *read_arg,
+			void *caller_arg);
 
-cortxfs_fsal_read cortxfs_fsal_reads[2] = {
-	kvsfs_read2,
-	kvsfs_perf_op_read2
-};
+typedef fsal_status_t (*cortxfs_fsal_mkdir)(struct fsal_obj_handle *dir_hdl,
+			const char *name, struct attrlist *attrs_in,
+			struct fsal_obj_handle **handle,
+			struct attrlist *attrs_out);
 
+static fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
+			const char *name, struct attrlist *attrs_in,
+			struct fsal_obj_handle **handle,
+			struct attrlist *attrs_out);
 
-// Adding support for kvsfs_getattrs
-typedef fsal_status_t (*cortxfs_fsal_getattr)(struct fsal_obj_handle *obj_hdl,
-                                  struct attrlist *attrs_out);
-static inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
-                                           struct attrlist *attrs_out);
-static inline fsal_status_t kvsfs_perf_op_getattrs(struct fsal_obj_handle *obj_hdl,
-                                                   struct attrlist *attrs_out);
-cortxfs_fsal_getattr cortxfs_fsal_getattrs[2] = {
-    kvsfs_getattrs,
-    kvsfs_perf_op_getattrs
-};
+static fsal_status_t kvsfs_perf_op_mkdir(struct fsal_obj_handle *dir_hdl,
+			const char *name, struct attrlist *attrs_in,
+			struct fsal_obj_handle **handle,
+			struct attrlist *attrs_out);
 
-// Adding support for kvsfs_setattrs
-typedef fsal_status_t (*cortxfs_fsal_setattr)(struct fsal_obj_handle *obj_hdl,
-                                    bool bypass,
-                                    struct state_t *state,
-                                    struct attrlist *attrs);
-static inline fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
-                                           bool bypass,
-                                           struct state_t *state,
-                                           struct attrlist *attrs);
-static inline fsal_status_t kvsfs_perf_op_setattrs(struct fsal_obj_handle *obj_hdl,
-                                                   bool bypass,
-                                                   struct state_t *state,
-                                                   struct attrlist *attrs);
-cortxfs_fsal_setattr cortxfs_fsal_setattrs[2] = {
-    kvsfs_setattrs,
-    kvsfs_perf_op_setattrs
-};
+typedef fsal_status_t (*cortxfs_fsal_readdir)(struct fsal_obj_handle *dir_hdl,
+			fsal_cookie_t *whence, void *dir_state,
+			fsal_readdir_cb cb, attrmask_t attrmask,
+			bool *eof);
 
-/**
- * CORTXFS PERF ENH:
- * Adding support for write2 
- **/
+static fsal_status_t kvsfs_readdir(struct fsal_obj_handle *dir_hdl,
+			fsal_cookie_t *whence, void *dir_state,
+			fsal_readdir_cb cb, attrmask_t attrmask,
+			bool *eof);
+
+static fsal_status_t kvsfs_perf_op_readdir(struct fsal_obj_handle *dir_hdl,
+			fsal_cookie_t *whence, void *dir_state,
+			fsal_readdir_cb cb, attrmask_t attrmask,
+			bool *eof);
+
+typedef fsal_status_t (*cortxfs_fsal_lookup)(struct fsal_obj_handle *parent_hdl,
+			const char *name, struct fsal_obj_handle **handle,
+			struct attrlist *attrs_out);
+
+static fsal_status_t kvsfs_lookup(struct fsal_obj_handle *parent_hdl,
+			const char *name, struct fsal_obj_handle **handle,
+			struct attrlist *attrs_out);
+
+static fsal_status_t kvsfs_perf_op_lookup(struct fsal_obj_handle *parent_hdl,
+			const char *name, struct fsal_obj_handle **handle,
+			struct attrlist *attrs_out);
 
 typedef void (*cortxfs_fsal_write)(struct fsal_obj_handle *obj_hdl,
 			bool bypass,
@@ -156,9 +157,61 @@ static inline void kvsfs_perf_op_write2(struct fsal_obj_handle *obj_hdl,
 			 struct fsal_io_arg *write_arg,
 			 void *caller_arg);
 
+// Adding support for kvsfs_getattrs
+typedef fsal_status_t (*cortxfs_fsal_getattr)(struct fsal_obj_handle *obj_hdl,
+                                  struct attrlist *attrs_out);
+static inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
+                                           struct attrlist *attrs_out);
+static inline fsal_status_t kvsfs_perf_op_getattrs(struct fsal_obj_handle *obj_hdl,
+                                                   struct attrlist *attrs_out);
+
+// Adding support for kvsfs_setattrs
+typedef fsal_status_t (*cortxfs_fsal_setattr)(struct fsal_obj_handle *obj_hdl,
+                                    bool bypass,
+                                    struct state_t *state,
+                                    struct attrlist *attrs);
+static fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
+                                           bool bypass,
+                                           struct state_t *state,
+                                           struct attrlist *attrs);
+static fsal_status_t kvsfs_perf_op_setattrs(struct fsal_obj_handle *obj_hdl,
+                                                   bool bypass,
+                                                   struct state_t *state,
+                                                   struct attrlist *attrs);
+
+cortxfs_fsal_getattr cortxfs_fsal_getattrs[2] = {
+    kvsfs_getattrs,
+    kvsfs_perf_op_getattrs
+};
+
+cortxfs_fsal_setattr cortxfs_fsal_setattrs[2] = {
+    kvsfs_setattrs,
+    kvsfs_perf_op_setattrs
+};
+
+cortxfs_fsal_read cortxfs_fsal_reads[2] = {
+	kvsfs_read2,
+	kvsfs_perf_op_read2
+};
+
 cortxfs_fsal_write cortxfs_fsal_writes[2] = {
 	kvsfs_write2,
 	kvsfs_perf_op_write2
+};
+
+cortxfs_fsal_mkdir cortxfs_fsal_mkdirs[2] = {
+	kvsfs_mkdir,
+	kvsfs_perf_op_mkdir
+};
+
+cortxfs_fsal_readdir cortxfs_fsal_readdirs[2] = {
+	kvsfs_readdir,
+	kvsfs_perf_op_readdir
+};
+
+cortxfs_fsal_lookup cortxfs_fsal_lookups[2] = {
+	kvsfs_lookup,
+	kvsfs_perf_op_lookup
 };
 
 /* Internal data types */
@@ -351,7 +404,7 @@ inline void cortxfs_cred_from_op_ctx(cfs_cred_t *out)
 
 /******************************************************************************/
 /* FSAL.lookup */
-static fsal_status_t kvsfs_lookup(struct fsal_obj_handle *parent_hdl,
+static inline fsal_status_t kvsfs_lookup(struct fsal_obj_handle *parent_hdl,
 				  const char *name,
 				  struct fsal_obj_handle **handle,
 				  struct attrlist *attrs_out)
@@ -363,12 +416,15 @@ static fsal_status_t kvsfs_lookup(struct fsal_obj_handle *parent_hdl,
 	struct kvsfs_fsal_export *export =
 	    container_of(op_ctx->fsal_export, struct kvsfs_fsal_export, export);
 
-	cortxfs_cred_from_op_ctx(&cred);
 
 	T_ENTER(">>> (%p, %s)", parent_hdl, name);
 
 	assert(name);
 	assert(strlen(name) > 0);
+
+	perfc_trace_state(PES_GEN_INIT);
+
+	cortxfs_cred_from_op_ctx(&cred);
 
 	if (!fsal_obj_handle_is(parent_hdl, DIRECTORY)) {
 		LogCrit(COMPONENT_FSAL,
@@ -396,8 +452,28 @@ static fsal_status_t kvsfs_lookup(struct fsal_obj_handle *parent_hdl,
 	if (object) {
 		cfs_fh_destroy(object);
 	}
+
+	perfc_trace_state(PES_GEN_FINI);
+
 	T_EXIT0(-rc);
 	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/* Wrapper of kvsfs_lookup with added support for TSDB for performance
+ * monitoring
+ */
+static fsal_status_t kvsfs_perf_op_lookup(struct fsal_obj_handle *parent_hdl,
+				  const char *name,
+				  struct fsal_obj_handle **handle,
+				  struct attrlist *attrs_out)
+{
+	fsal_status_t result;
+	int64_t myopid = perf_id_gen();
+
+	perfc_tls_ini(TSDB_MOD_FSUSER, myopid, PFT_FSAL_LOOKUP);
+	result = kvsfs_lookup(parent_hdl, name, handle, attrs_out);
+	perfc_tls_fini();
+	return result;
 }
 
 /******************************************************************************/
@@ -530,7 +606,7 @@ out:
 
 /******************************************************************************/
 /* FSAL.mkdir - Create a directory */
-static fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
+static inline fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
 				const char *name, struct attrlist *attrs_in,
 				struct fsal_obj_handle **handle,
 				struct attrlist *attrs_out)
@@ -543,6 +619,8 @@ static fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
 	mode_t unix_mode;
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 	struct attrlist parent_attrs = {0};
+
+	perfc_trace_state(PES_GEN_INIT);
 
 	cortxfs_cred_from_op_ctx(&cred);
 	/* TODO:PERF: Check if it can be converted into an assert pre-cond */
@@ -587,6 +665,8 @@ static fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
 		 *  access checks using ACLs are implemented.
 		 */
 
+		perfc_trace_attr(PEA_OTHER_FUNC_CALL, 1);
+
 		/* Try to get ACL of the parent directory, and set them
                    on the child directory. */
 		fsal_prepare_attrs(&parent_attrs, ATTR_ACL);
@@ -614,13 +694,35 @@ static fsal_status_t kvsfs_mkdir(struct fsal_obj_handle *dir_hdl,
 				        "Set acl on dir %p failed", hdl);
 				 goto free_attrs;
 		}
+
+		perfc_trace_attr(PEA_OTHER_FUNC_END, 1);
+
 	} /* if (kvsfs_is_acl_enabled()) */
 
 free_attrs:
 	fsal_release_attrs(&parent_attrs);
 
 out:
+	perfc_trace_state(PES_GEN_FINI);
+
 	T_EXIT0(status.major);
+	return status;
+}
+
+/* Wrapper of kvsfs_mkdir with added support for TSDB for performance
+ * monitoring
+ */
+static fsal_status_t kvsfs_perf_op_mkdir(struct fsal_obj_handle *dir_hdl,
+				const char *name, struct attrlist *attrs_in,
+				struct fsal_obj_handle **handle,
+				struct attrlist *attrs_out)
+{
+	uint64_t myopid = perf_id_gen();
+	fsal_status_t status;
+
+	perfc_tls_ini(TSDB_MOD_FSUSER, myopid, PFT_FSAL_MKDIR);
+	status = kvsfs_mkdir(dir_hdl, name, attrs_in, handle, attrs_out);
+	perfc_tls_fini();
 	return status;
 }
 
@@ -907,11 +1009,10 @@ err_out:
 	return retval;
 }
 
-static fsal_status_t kvsfs_readdir(struct fsal_obj_handle *dir_hdl,
+static inline fsal_status_t kvsfs_readdir(struct fsal_obj_handle *dir_hdl,
 				  fsal_cookie_t *whence, void *dir_state,
 				  fsal_readdir_cb cb, attrmask_t attrmask,
 				  bool *eof)
-
 {
 	struct kvsfs_fsal_obj_handle *obj;
 	cfs_cred_t cred;
@@ -935,6 +1036,8 @@ static fsal_status_t kvsfs_readdir(struct fsal_obj_handle *dir_hdl,
 
 	struct cfs_fs *cfs_fs = NULL;
 	int rc;
+
+	perfc_trace_state(PES_GEN_INIT);
 
 	cortxfs_cred_from_op_ctx(&cred);
 	obj = container_of(dir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
@@ -980,8 +1083,27 @@ static fsal_status_t kvsfs_readdir(struct fsal_obj_handle *dir_hdl,
 	*eof = readdir_ctx.eof;
 
  out:
+	perfc_trace_state(PES_GEN_FINI);
+
 	T_EXIT0(-rc);
 	return fsalstat(posix2fsal_error(-rc), -rc);
+}
+
+/* Wrapper of kvsfs_readdir with added support for TSDB for performance
+ * monitoring
+ */  
+static fsal_status_t kvsfs_perf_op_readdir(struct fsal_obj_handle *dir_hdl,
+				  fsal_cookie_t *whence, void *dir_state,
+				  fsal_readdir_cb cb, attrmask_t attrmask,
+				  bool *eof)
+{
+	uint64_t myopid = perf_id_gen();
+	fsal_status_t status;
+
+	perfc_tls_ini(TSDB_MOD_FSUSER, myopid, PFT_FSAL_READDIR);
+	status = kvsfs_readdir(dir_hdl, whence, dir_state, cb, attrmask, eof);
+	perfc_tls_fini();
+	return status;
 }
 
 /******************************************************************************/
@@ -1582,6 +1704,10 @@ static fsal_status_t kvsfs_rmdir(struct fsal_obj_handle *dir_hdl,
 	cfs_cred_t cred;
 	struct kvsfs_fsal_obj_handle *parent;
 	int rc;
+	uint64_t myopid = perf_id_gen();
+
+	perfc_tls_ini(TSDB_MOD_FSUSER, myopid, PFT_FSAL_RMDIR);
+	perfc_trace_state(PES_GEN_INIT);
 
 	cortxfs_cred_from_op_ctx(&cred);
 	parent = container_of(dir_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
@@ -1603,6 +1729,9 @@ static fsal_status_t kvsfs_rmdir(struct fsal_obj_handle *dir_hdl,
 	}
 
 out:
+	perfc_trace_state(PES_GEN_FINI);
+	perfc_tls_fini();
+
 	return fsalstat(posix2fsal_error(-rc), -rc);
 }
 
@@ -3263,9 +3392,9 @@ void kvsfs_handle_ops_init(struct fsal_obj_ops *ops)
 
 	// Namespace
 	ops->release = release;
-	ops->lookup = kvsfs_lookup;
-	ops->readdir = kvsfs_readdir;
-	ops->mkdir = kvsfs_mkdir;
+	ops->lookup = cortxfs_fsal_lookups[enable_mon];
+	ops->readdir = cortxfs_fsal_readdirs[enable_mon];
+	ops->mkdir = cortxfs_fsal_mkdirs[enable_mon];
 	/* mknode is unsupported by KVSFS */
 
 	ops->symlink = kvsfs_makesymlink;
@@ -3303,7 +3432,7 @@ void kvsfs_handle_ops_init(struct fsal_obj_ops *ops)
 	 */
 
 	ops->lease_op2 = kvsfs_lease_op2;
-   handle_ops_pnfs(ops);
+	handle_ops_pnfs(ops);
 	/* TODO:PORTING: Disable xattrs support */
 #if 0
 	/* xattr related functions */


### PR DESCRIPTION
# CORTXFS FSAL Change Summary

## Problem Statement
_[EOS-13992](https://jts.seagate.com/browse/EOS-13992):_
_ADDB Tracepoints-Directory Operations_

## Problem Description
_Add ADDB tracepoints for Directory operations_

## Solution Overview
_Directory operations include, directory creation (mkdir), directory removal (rmdir), read the directory contents (readdir) and lookup a specific entry in directory (lookup). ADDB tracepoint added for function entry and points. This provides information on how much time the function / code snippet takes._

### Companion PRs
https://github.com/Seagate/cortx-utils/pull/48
https://github.com/Seagate/cortx-fs/pull/41
https://github.com/Seagate/cortx-nsal/pull/23

## Unit Test Cases
_No new test cases added_

## Testing
<details>
  <summary>Click here to see the test execution output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 1
Tests passed = 1
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0


```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [X] **Sanity Testing:** _Done as mentioned in testing above_
- [X] **Documentation:** _None_