### PR TITLE
EOS-13996:ADDB:Profiling for all I/O operations (cortx-fs-ganesha repo)

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/addb_cfs_plugin.c
+++ b/src/FSAL/FSAL_CORTXFS/addb_cfs_plugin.c
@@ -87,6 +87,8 @@ static const struct entity_attrs_items {
   const char* str;
 } g_entity_attrs_items_map[] = {
   [PEA_W_OFFSET] = { .str = "write_offset" },
+  [PEA_W_IOVC] = { .str = "write_iovc" },
+  [PEA_W_IOVL] = { .str = "write_iovl" },
   [PEA_W_SIZE] = { .str = "write_size" },
   [PEA_W_RES_MAJ] = { .str = "write_result_major_code" },
   [PEA_W_RES_MIN] = { .str = "write_result_minor_code" },
@@ -393,6 +395,26 @@ static void decode_perfc_function_tags(struct m0_addb2__context *ctx,
   strcpy(buf, g_function_tag_items_map[*v].str);
 }
 
+static const struct submodule_tag_items {
+	const char* str;
+} g_sm_tag_items_map[] = {
+	[PSMTR_A] = { .str = "CFS"  },
+	[PSMTR_B] = { .str = "FSAL_CFS"  },
+	[PSMTR_C] = { .str = "DSAL"  },
+	[PSMTR_D] = { .str = "NSAL"  },
+	[PSMTR_E] = { .str = "UTILS"  },
+	[PSMTR_F] = { .str = "RESERVED"  },
+};
+
+_Static_assert(ARRAY_SIZE(g_sm_tag_items_map) <= PSMTR_END, "Invalid sm tag");
+
+static void decode_perfc_sm_tags(struct m0_addb2__context *ctx,
+			         const uint64_t *v, char *buf)
+{
+	M0_PRE(*v < PSMTR_END);
+	strcpy(buf, g_sm_tag_items_map[*v].str);
+}
+
 static const struct entry_type_items {
   const char* str;
 } g_entry_type_items_map[] = {
@@ -415,6 +437,7 @@ static struct m0_addb2__id_intrp gs_curr_ids[] = {
         "fsuser_state",
         {
             &decode_perfc_function_tags,
+            &decode_perfc_sm_tags,
             &decode_perfc_entry_type,
             &hex, // operation id
             &decode_perfc_entity_states
@@ -425,6 +448,7 @@ static struct m0_addb2__id_intrp gs_curr_ids[] = {
         "fsuser_attribute",
         {
             &decode_perfc_function_tags,
+            &decode_perfc_sm_tags,
             &decode_perfc_entry_type,
             &hex, // operation id
             &decode_perfc_entity_attrs,
@@ -436,6 +460,7 @@ static struct m0_addb2__id_intrp gs_curr_ids[] = {
         "fsuser_map",
         {
             &decode_perfc_function_tags,
+            &decode_perfc_sm_tags,
             &decode_perfc_entry_type,
             &hex, // map name
             &hex, // operation id

--- a/src/FSAL/FSAL_CORTXFS/cfs_ganesha_perfc.h
+++ b/src/FSAL/FSAL_CORTXFS/cfs_ganesha_perfc.h
@@ -58,6 +58,8 @@ enum perfc_fsal_entity_attrs {
 	PEA_FSAL_START = PEAR_RANGE_2_START,
 	PEA_W_OFFSET,
 	PEA_W_SIZE,
+	PEA_W_IOVC,
+	PEA_W_IOVL,
 	PEA_W_RES_MAJ,
 	PEA_W_RES_MIN,
 	PEA_R_OFFSET,

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -3495,9 +3495,9 @@ static inline void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
 		(unsigned long long) write_arg->iov[0].iov_len);
 
 	perfc_trace_state(PES_GEN_INIT);
-	perfc_trace_attr(PEA_R_OFFSET, write_arg->offset);
-	perfc_trace_attr(PEA_R_IOVC, write_arg->iov_count);
-	perfc_trace_attr(PEA_R_IOVL, write_arg->iov[0].iov_len);
+	perfc_trace_attr(PEA_W_OFFSET, write_arg->offset);
+	perfc_trace_attr(PEA_W_IOVC, write_arg->iov_count);
+	perfc_trace_attr(PEA_W_IOVL, write_arg->iov[0].iov_len);
 
 	/* So far, NFS Ganesha always sends only a single buffer in a FSAL.
 	 * We can use this information for keeping write2 implementation
@@ -3539,8 +3539,8 @@ static inline void kvsfs_write2(struct fsal_obj_handle *obj_hdl,
 
 	result = fsalstat(ERR_FSAL_NO_ERROR, 0);
 out:
-	perfc_trace_attr(PEA_R_RES_MAJ, result.major);
-	perfc_trace_attr(PEA_R_RES_MIN, result.minor);
+	perfc_trace_attr(PEA_W_RES_MAJ, result.major);
+	perfc_trace_attr(PEA_W_RES_MIN, result.minor);
 	perfc_trace_state(PES_GEN_FINI);
 
 	T_EXIT0(result.major);


### PR DESCRIPTION
#  EOS-13996:ADDB:Profiling for all I/O operations (cortx-fs-ganesha repo)

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _This patch has been squashed and re-based, it can be merged using fast-forward merge_
- [] **Code review:** _All discussions have been resolved_
- [x] **Sanity Testing:** _All Unit tests are passing and able to do mount and io operations works from NFS client_
- [x] **Documentation:** _This patch and merge request have up to date description_
- [x] **Unit Testing and debugging:** _Both single and multi node changes are unit tested_

## UT

[root@ssc-vm-c-0040 /]# ./cortx-posix/scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

## Commit Message
commit a80692dbe6ada97f0f0bf4a03ec5d2f33166747b
Author: pratyush-seagate <pratyush.k.khan@seagate.com>
Date:   Tue Oct 27 16:19:18 2020 -0600

                EOS-13996:ADDB:Profiling for all I/O operations (cortx-fs-ganesha repo)

                List of modified files:
                modified:   src/FSAL/FSAL_CORTXFS/handle.c
                Change description:
                    Write attr fixes
            Unit test:
                     histogram generation
