### PR TITLE
EOS-9010: File handle support for cortxfs API's (cortx-fs-ganesha repo)

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -1700,8 +1700,10 @@ static inline fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
 				     kvsfs_fh_to_ino(obj->handle), &fh);
 		if (rc == 0) {
 			rc1 = cfs_setattr(fh, &cred, &stats, flags);
+			result = fsalstat(posix2fsal_error(-rc1), -rc1);
+		} else {
+			result = fsalstat(posix2fsal_error(-rc), -rc);
 		}
-		result = fsalstat(posix2fsal_error(-rc1), -rc1);
 		if (fh) {
 			if (rc1 == 0) {
 				cfs_fh_destroy_and_dump_stat(fh);

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -1494,7 +1494,8 @@ static  inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
 	 * When all such dependency is removed, the FH will be
 	 * extracted directly from kvsfs_fsal_obj_handle.
 	 */
-	retval = cfs_fh_from_ino(myself->cfs_fs, &ino, &fh);
+	//retval = cfs_fh_from_ino(myself->cfs_fs, &ino, &fh);
+	fh = myself->handle;
 	stat = cfs_fh_stat(fh);
 
 	result = fsalstat(posix2fsal_error(-retval), retval);


### PR DESCRIPTION
# cortx-fs-ganesha Change Summary

## Problem Statement
_[EOS-9010](https://jts.seagate.com/browse/EOS-9010):_
_File handle support for cortxfs API's_

## Problem Description
_The current implementation relies on cfs_fs and inode, that should be eliminated_

## Solution Overview
_Modified relevant API's to use FH_

## Unit Test Cases
_Build, UT testing, ensure no errors_

## Testing
<details>
  <summary>Click here to see the build output</summary>

```
[root@ssc-vm-c-0689 cortx-posix]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 14
Tests passed = 14
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

```

</details>


## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [ ] **Code review:** _In progress_
- [x] **Sanity Testing:** _Completed as mentioned above_
- [ ] **Documentation:** _TBD_

Relevant PR's for this :
https://github.com/Seagate/cortx-posix/pull/295
https://github.com/Seagate/cortx-fs/pull/70/