### PR TITLE
EOS-9010: File handle support for cortxfs API's (cortx-fs-ganesha repo)

### DIFF
--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -1470,14 +1470,16 @@ static  inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
                                             struct attrlist *attrs_out)
 {
 	struct kvsfs_fsal_obj_handle *myself;
-	struct stat stat;
 	int retval = 0;
+	cfs_ino_t * ino = NULL;
+	struct stat *stat = NULL;
+	struct cfs_fh * fh = NULL;
 	cfs_cred_t cred;
 	fsal_status_t result;
 
 	cortxfs_cred_from_op_ctx(&cred);
 	T_ENTER(">>> (%p)", obj_hdl);
-    perfc_trace_state(PES_GEN_INIT);
+	perfc_trace_state(PES_GEN_INIT);
 
 	if (attrs_out == NULL) {
 		retval = 0;
@@ -1486,16 +1488,23 @@ static  inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
 
 	myself =
 		container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
-
-	retval = cfs_getattr(myself->cfs_fs, &cred,
-			     kvsfs_fh_to_ino(myself->handle), &stat);
+	/* TODO : Remove call to cfs_fh_from_ino
+	 * Currently, FH is temporarily obtained from the disk
+	 * because still FH is not in use at all the places.
+	 * When all such dependency is removed, the FH will be
+	 * extracted directly from kvsfs_fsal_obj_handle.
+	 */
+	//fh = myself->handle;
+	ino = kvsfs_fh_to_ino(myself->handle);
+	retval = cfs_fh_from_ino(myself->cfs_fs, ino, &fh);
+	stat = cfs_fh_stat(fh);
 
 	result = fsalstat(posix2fsal_error(-retval), retval);
 	if (FSAL_IS_ERROR(result)) {
 		goto out;
 	}
 
-	posix2fsal_attributes_all(&stat, attrs_out);
+	posix2fsal_attributes_all(stat, attrs_out);
 	if (kvsfs_is_acl_enabled()) {
 		fsal_acl_t *acl = NULL;
 		result = kvsfs_getacl(myself, &cred, &acl);
@@ -1516,6 +1525,9 @@ static  inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
 	}
 
 out:
+	if (fh) {
+		cfs_fh_destroy(fh);
+	}
 	T_EXIT0(result.major);
     perfc_trace_attr(PEA_GETATTR_RES_MAJ, result.major);
     perfc_trace_attr(PEA_GETATTR_RES_MIN, result.minor);
@@ -1620,9 +1632,10 @@ static inline fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
                                            struct attrlist *attrs)
 {
 	fsal_status_t result;
-	int rc;
+	int rc, rc1;
 	struct kvsfs_fsal_obj_handle *obj;
 	struct stat stats = { 0 };
+	struct cfs_fh *fh = NULL;
 	int flags = 0;
 	cfs_cred_t cred;
 
@@ -1694,10 +1707,21 @@ static inline fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
 		/* If the size does not need to be change, then
 		 * we can simply update the stats associated with the inode.
 		 */
-		rc = cfs_setattr(obj->cfs_fs, &cred,
-				 kvsfs_fh_to_ino(obj->handle),
-				 &stats, flags);
-		result = fsalstat(posix2fsal_error(-rc), -rc);
+		rc = cfs_fh_from_ino(obj->cfs_fs,
+				     kvsfs_fh_to_ino(obj->handle), &fh);
+		if (rc == 0) {
+			rc1 = cfs_setattr(fh, &cred, &stats, flags);
+			result = fsalstat(posix2fsal_error(-rc1), -rc1);
+		} else {
+			result = fsalstat(posix2fsal_error(-rc), -rc);
+		}
+		if (fh) {
+			if (rc1 == 0) {
+				cfs_fh_destroy_and_dump_stat(fh);
+			} else {
+				cfs_fh_destroy(fh);
+			}
+		}
 	}
 
 out:
@@ -2450,12 +2474,15 @@ static fsal_status_t kvsfs_open2_by_handle(struct fsal_obj_handle *obj_hdl,
 	fsal_status_t status = fsalstat(ERR_FSAL_NO_ERROR, 0);
 	cfs_cred_t cred;
 	struct kvsfs_file_state *fd;
-	struct stat stat;
+	cfs_ino_t * ino = NULL;
+	struct stat *stat = NULL;
+	struct cfs_fh * fh = NULL;
 
 	perfc_trace_inii(PFT_OPEN2_BY_HANDLE, PEM_FSAL_TO_NFS);
 	cortxfs_cred_from_op_ctx(&cred);
 	fd = &container_of(state, struct kvsfs_state_fd, state)->kvsfs_fd;
 	obj = container_of(obj_hdl, struct kvsfs_fsal_obj_handle, obj_handle);
+	ino = kvsfs_fh_to_ino(obj->handle);
 
 	status = kvsfs_file_state_open(fd, openflags, obj, false);
 	if (FSAL_IS_ERROR(status)) {
@@ -2463,14 +2490,14 @@ static fsal_status_t kvsfs_open2_by_handle(struct fsal_obj_handle *obj_hdl,
 	}
 
 	if (attrs_out != NULL) {
-		rc = cfs_getattr(obj->cfs_fs, &cred,
-				 kvsfs_fh_to_ino(obj->handle), &stat);
+		rc = cfs_fh_from_ino(obj->cfs_fs, ino, &fh);
+		stat = cfs_fh_stat(fh);
 		if (rc < 0) {
 			status = fsalstat(posix2fsal_error(-rc), -rc);
 			goto out;
 		}
 
-		posix2fsal_attributes_all(&stat, attrs_out);
+		posix2fsal_attributes_all(stat, attrs_out);
 	}
 
 	/* kvsfs_file_state_open does not call test_access and

--- a/src/FSAL/FSAL_CORTXFS/handle.c
+++ b/src/FSAL/FSAL_CORTXFS/handle.c
@@ -1494,15 +1494,14 @@ static  inline fsal_status_t kvsfs_getattrs(struct fsal_obj_handle *obj_hdl,
 	 * When all such dependency is removed, the FH will be
 	 * extracted directly from kvsfs_fsal_obj_handle.
 	 */
-	//fh = myself->handle;
 	ino = kvsfs_fh_to_ino(myself->handle);
 	retval = cfs_fh_from_ino(myself->cfs_fs, ino, &fh);
-	stat = cfs_fh_stat(fh);
-
 	result = fsalstat(posix2fsal_error(-retval), retval);
 	if (FSAL_IS_ERROR(result)) {
 		goto out;
 	}
+
+	stat = cfs_fh_stat(fh);
 
 	posix2fsal_attributes_all(stat, attrs_out);
 	if (kvsfs_is_acl_enabled()) {
@@ -1706,6 +1705,12 @@ static inline fsal_status_t kvsfs_setattrs(struct fsal_obj_handle *obj_hdl,
 	} else {
 		/* If the size does not need to be change, then
 		 * we can simply update the stats associated with the inode.
+		 */
+		/* TODO : Remove call to cfs_fh_from_ino
+		 * Currently, FH is temporarily obtained from the disk
+		 * because still FH is not in use at all the places.
+		 * When all such dependency is removed, the FH will be
+		 * extracted directly from kvsfs_fsal_obj_handle.
 		 */
 		rc = cfs_fh_from_ino(obj->cfs_fs,
 				     kvsfs_fh_to_ino(obj->handle), &fh);
@@ -2490,12 +2495,18 @@ static fsal_status_t kvsfs_open2_by_handle(struct fsal_obj_handle *obj_hdl,
 	}
 
 	if (attrs_out != NULL) {
+		/* TODO : Remove call to cfs_fh_from_ino
+		 * Currently, FH is temporarily obtained from the disk
+		 * because still FH is not in use at all the places.
+		 * When all such dependency is removed, the FH will be
+		 * extracted directly from kvsfs_fsal_obj_handle.
+		 */
 		rc = cfs_fh_from_ino(obj->cfs_fs, ino, &fh);
-		stat = cfs_fh_stat(fh);
 		if (rc < 0) {
 			status = fsalstat(posix2fsal_error(-rc), -rc);
 			goto out;
 		}
+		stat = cfs_fh_stat(fh);
 
 		posix2fsal_attributes_all(stat, attrs_out);
 	}


### PR DESCRIPTION
# cortx-fs-ganesha Change Summary

## Problem Statement
_[EOS-9010](https://jts.seagate.com/browse/EOS-9010):_
_File handle support for cortxfs API's_

## Problem Description
_The current implementation relies on cfs_fs and inode, that should be eliminated_

## Solution Overview
_Modified relevant API's to use FH_

## Unit Test Cases
_Build, UT testing, ensure no errors_

## Testing
<details>
  <summary>Click here to see the script test output</summary>

```
[root@ssc-vm-c-1561 cortx-posix-9010]# ./scripts/test.sh
 --
 --
Configuration Completed
Clean indexes prepared
NSAL Unit tests
NS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Iterator test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

KVTree test
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

Global KVS Tests
Test results are logged to /var/log/cortx/test/ut/ut_nsal.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

CORTXFS Unit tests
Endpoint ops Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.logs
Total tests  = 4
Tests passed = 4
Tests failed = 0

FS Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Directory tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 17
Tests passed = 17
Tests failed = 0

File creation tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 4
Tests passed = 4
Tests failed = 0

Link Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 6
Tests passed = 6
Tests failed = 0

Rename tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 3
Tests passed = 3
Tests failed = 0

Attribute Tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 5
Tests passed = 5
Tests failed = 0

Xattr file Tests
Test results are logged to /var/log/cortx/test/ut/xattr_file_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

Xattr dir Tests
Test results are logged to /var/log/cortx/test/ut/xattr_dir_ops.log
Total tests  = 9
Tests passed = 9
Tests failed = 0

IO tests
Test results are logged to /var/log/cortx/test/ut/ut_cortxfs.log
Total tests  = 7
Tests passed = 7
Tests failed = 0

DSAL Unit tests
Dsal basic test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 11
Tests passed = 11
Tests failed = 0

Dsal IO test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

Dsal space stats test
Test results are logged to /var/log/cortx/test/ut/ut_dsal.log
Total tests  = 2
Tests passed = 2
Tests failed = 0

```

</details>

<details>
  <summary>Click here to see the cthon output</summary>

```
[root@ssc-vm-c-1561 cortx-posix-9010]# /opt/seagate/cortx/fs-ganesha/test/run_cthon.sh -m /mnt/dir1 -p testFS -a
sh ./runtests  -a -t /mnt/dir1/ssc-vm-c-1561.test

Starting BASIC tests: test directory /mnt/dir1/ssc-vm-c-1561.test (arg: -t)

./test1: File and directory creation test
        created 4 files 2 directories 2 levels deep in 0.20 seconds
        ./test1 ok.

./test2: File and directory removal test
        removed 4 files 2 directories 2 levels deep in 0.17 seconds
        ./test2 ok.

./test3: lookups across mount point
        500 getcwd and stat calls in 0.0  seconds
        ./test3 ok.

./test4: setattr, getattr, and lookup
        1000 chmods and stats on 10 files in 6.32 seconds
        ./test4 ok.
./test4a: getattr and lookup
        1000 stats on 10 files in 0.1  seconds
        ./test4a ok.

TESTARG=-t
./test6: readdir
        7500 entries read, 120 files in 45.25 seconds
        ./test6 ok.

./test7: link and rename
        200 renames and links on 10 files in 9.35 seconds
        ./test7 ok.

./test8: symlink and readlink
        400 symlinks and readlinks on 10 files in 9.30 seconds
        ./test8 ok.

./test9: statfs
        1500 statfs calls in 2.64 seconds
        ./test9 ok.

Congratulations, you passed the basic tests!

GENERAL TESTS: directory /mnt/dir1/ssc-vm-c-1561.test
if test ! -x runtests; then chmod a+x runtests; fi
cd /mnt/dir1/ssc-vm-c-1561.test; rm -f Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst
cp Makefile runtests runtests.wrk *.sh *.c mkdummy rmdummy nroff.in makefile.tst /mnt/dir1/ssc-vm-c-1561.test

Small Compile
smcomp.time
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Tbl
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Nroff
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Large Compile
        0.1 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

Four simultaneous large compiles
        0.2 (0.0) real  0.1 (0.0) user  0.0 (0.0) sys

Makefile
        0.0 (0.0) real  0.0 (0.0) user  0.0 (0.0) sys

General tests complete

SPECIAL TESTS: directory /mnt/dir1/ssc-vm-c-1561.test
cd /mnt/dir1/ssc-vm-c-1561.test; rm -f runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp
cp runtests runtests.wrk READWIN.txt Makefile op_unlk op_ren op_chmod dupreq excltest negseek rename holey truncate nfsidem nstat stat stat2 touchn fstat rewind telldir bigfile bigfile2 freesp /mnt/dir1/ssc-vm-c-1561.test

check for proper open/unlink operation
nfsjunk files before unlink:
  -rw-rw-rw- 1 root root 0 Dec  7 23:38 ./nfsjDkmDx
./nfsjDkmDx open; unlink ret = 0
nfsjunk files after unlink:
  ls: cannot access ./nfsjDkmDx: No such file or directory
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsjDkmDx: No such file or directory
test completed successfully.

check for proper open/rename operation
nfsjunk files before rename:
  -rwxrwxrwx 1 root root 0 Dec  7 23:38 ./nfsa5GBf2F
  -rwxrwxrwx 1 root root 0 Dec  7 23:38 ./nfsbG3CFdx
./nfsbG3CFdx open; rename ret = 0
nfsjunk files after rename:
  ls: cannot access ./nfsa5GBf2F: No such file or directory
  -rwxrwxrwx 1 root root 0 Dec  7 23:38 ./nfsbG3CFdx
data compare ok
nfsjunk files after close:
  ls: cannot access ./nfsa5GBf2F: No such file or directory
  ls: cannot access ./nfsbG3CFdx: No such file or directory
test completed successfully.

check for proper open/chmod 0 operation
testfile before chmod:
  -rw-rw-rw- 1 root root 0 Dec  7 23:38 ./nfsmvZiw3
./nfsmvZiw3 open; chmod ret = 0
testfile after chmod:
  ---------- 1 root root 0 Dec  7 23:38 ./nfsmvZiw3
data compare ok
testfile after write/read:
  ---------- 1 root root 100 Dec  7 23:38 ./nfsmvZiw3
test completed successfully.

check for lost reply on non-idempotent requests
100 tries

test exclusive create.

test negative seek, you should get: read: Invalid argument
or lseek: Invalid argument
lseek: Invalid argument

test rename

test truncate
truncate succeeded

test holey file support
Holey file test ok

second check for lost reply on non-idempotent requests
testing 50 idempotencies in directory "testdir"

test rewind support

test telldir cookies

test freesp and file size
fcntl(...F_FREESP...) not available on this platform.

write/read 30 MB file

write/read at 2GB, 4GB edges

Special tests complete

Starting LOCKING tests: test directory /mnt/dir1/ssc-vm-c-1561.test (arg: -t)

Testing native post-LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3280 msecs. [36585 lpm].

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [499.03 +/- 1.56 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [473.64 +/- 8.00 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).

Testing non-native 64 bit LFS locking

Creating parent/child synchronization pipes.

Test #1 - Test regions of an unlocked file.
        Parent: 1.1  - F_TEST  [               0,               1] PASSED.
        Parent: 1.2  - F_TEST  [               0,          ENDING] PASSED.
        Parent: 1.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Parent: 1.4  - F_TEST  [               1,               1] PASSED.
        Parent: 1.5  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 1.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Parent: 1.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Parent: 1.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Parent: 1.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.

Test #2 - Try to lock the whole file.
        Parent: 2.0  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  2.1  - F_TEST  [               0,               1] PASSED.
        Child:  2.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  2.3  - F_TEST  [               0,7fffffffffffffff] PASSED.
        Child:  2.4  - F_TEST  [               1,               1] PASSED.
        Child:  2.5  - F_TEST  [               1,          ENDING] PASSED.
        Child:  2.6  - F_TEST  [               1,7fffffffffffffff] PASSED.
        Child:  2.7  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  2.8  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  2.9  - F_TEST  [7fffffffffffffff,7fffffffffffffff] PASSED.
        Parent: 2.10 - F_ULOCK [               0,          ENDING] PASSED.

Test #3 - Try to lock just the 1st byte.
        Parent: 3.0  - F_TLOCK [               0,               1] PASSED.
        Child:  3.1  - F_TEST  [               0,               1] PASSED.
        Child:  3.2  - F_TEST  [               0,          ENDING] PASSED.
        Child:  3.3  - F_TEST  [               1,               1] PASSED.
        Child:  3.4  - F_TEST  [               1,          ENDING] PASSED.
        Parent: 3.5  - F_ULOCK [               0,               1] PASSED.

Test #4 - Try to lock the 2nd byte, test around it.
        Parent: 4.0  - F_TLOCK [               1,               1] PASSED.
        Child:  4.1  - F_TEST  [               0,               1] PASSED.
        Child:  4.2  - F_TEST  [               0,               2] PASSED.
        Child:  4.3  - F_TEST  [               0,          ENDING] PASSED.
        Child:  4.4  - F_TEST  [               1,               1] PASSED.
        Child:  4.5  - F_TEST  [               1,               2] PASSED.
        Child:  4.6  - F_TEST  [               1,          ENDING] PASSED.
        Child:  4.7  - F_TEST  [               2,               1] PASSED.
        Child:  4.8  - F_TEST  [               2,               2] PASSED.
        Child:  4.9  - F_TEST  [               2,          ENDING] PASSED.
        Parent: 4.10 - F_ULOCK [               1,               1] PASSED.

Test #5 - Try to lock 1st and 2nd bytes, test around them.
        Parent: 5.0  - F_TLOCK [               0,               1] PASSED.
        Parent: 5.1  - F_TLOCK [               2,               1] PASSED.
        Child:  5.2  - F_TEST  [               0,               1] PASSED.
        Child:  5.3  - F_TEST  [               0,               2] PASSED.
        Child:  5.4  - F_TEST  [               0,          ENDING] PASSED.
        Child:  5.5  - F_TEST  [               1,               1] PASSED.
        Child:  5.6  - F_TEST  [               1,               2] PASSED.
        Child:  5.7  - F_TEST  [               1,          ENDING] PASSED.
        Child:  5.8  - F_TEST  [               2,               1] PASSED.
        Child:  5.9  - F_TEST  [               2,               2] PASSED.
        Child:  5.10 - F_TEST  [               2,          ENDING] PASSED.
        Child:  5.11 - F_TEST  [               3,               1] PASSED.
        Child:  5.12 - F_TEST  [               3,               2] PASSED.
        Child:  5.13 - F_TEST  [               3,          ENDING] PASSED.
        Parent: 5.14 - F_ULOCK [               0,               1] PASSED.
        Parent: 5.15 - F_ULOCK [               2,               1] PASSED.

Test #6 - Try to lock the MAXEOF byte.
        Parent: 6.0  - F_TLOCK [7fffffffffffffff,               1] PASSED.
        Child:  6.1  - F_TEST  [7ffffffffffffffe,               1] PASSED.
        Child:  6.2  - F_TEST  [7ffffffffffffffe,               2] PASSED.
        Child:  6.3  - F_TEST  [7ffffffffffffffe,          ENDING] PASSED.
        Child:  6.4  - F_TEST  [7fffffffffffffff,               1] PASSED.
        Child:  6.5  - F_TEST  [7fffffffffffffff,               2] PASSED.
        Child:  6.6  - F_TEST  [7fffffffffffffff,          ENDING] PASSED.
        Child:  6.7  - F_TEST  [8000000000000000,          ENDING] PASSED.
        Child:  6.8  - F_TEST  [8000000000000000,               1] PASSED.
        Child:  6.9  - F_TEST  [8000000000000000,7fffffffffffffff] PASSED.
        Child:  6.10 - F_TEST  [8000000000000000,8000000000000000] PASSED.
        Parent: 6.11 - F_ULOCK [7fffffffffffffff,               1] PASSED.

Test #7 - Test parent/child mutual exclusion.
        Parent: 7.0  - F_TLOCK [             ffc,               9] PASSED.
        Parent: Wrote 'aaaa eh' to testfile [ 4092, 7 ].
        Parent: Now free child to run, should block on lock.
        Parent: Check data in file to insure child blocked.
        Parent: Read 'aaaa eh' from testfile [ 4092, 7 ].
        Parent: 7.1  - COMPARE [             ffc,               7] PASSED.
        Parent: Now unlock region so child will unblock.
        Parent: 7.2  - F_ULOCK [             ffc,               9] PASSED.
        Child:  7.3  - F_LOCK  [             ffc,               9] PASSED.
        Child:  Write child's version of the data and release lock.
        Parent: Now try to regain lock, parent should block.
        Child:  Wrote 'bebebebeb' to testfile [ 4092, 9 ].
        Child:  7.4  - F_ULOCK [             ffc,               9] PASSED.
        Parent: 7.5  - F_LOCK  [             ffc,               9] PASSED.
        Parent: Check data in file to insure child unblocked.
        Parent: Read 'bebebebeb' from testfile [ 4092, 9 ].
        Parent: 7.6  - COMPARE [             ffc,               9] PASSED.
        Parent: 7.7  - F_ULOCK [             ffc,               9] PASSED.

Test #8 - Rate test performing lock/unlock cycles.
        Parent: Performed 1000 lock/unlock cycles in 3140 msecs. [38216 lpm].

Test #10 - Make sure a locked region is split properly.
        Parent: 10.0  - F_TLOCK [               0,               3] PASSED.
        Parent: 10.1  - F_ULOCK [               1,               1] PASSED.
        Child:  10.2  - F_TEST  [               0,               1] PASSED.
        Child:  10.3  - F_TEST  [               2,               1] PASSED.
        Child:  10.4  - F_TEST  [               3,          ENDING] PASSED.
        Child:  10.5  - F_TEST  [               1,               1] PASSED.
        Parent: 10.6  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.7  - F_ULOCK [               2,               1] PASSED.
        Child:  10.8  - F_TEST  [               0,               3] PASSED.
        Parent: 10.9  - F_ULOCK [               0,               1] PASSED.
        Parent: 10.10 - F_TLOCK [               1,               3] PASSED.
        Parent: 10.11 - F_ULOCK [               2,               1] PASSED.
        Child:  10.12 - F_TEST  [               1,               1] PASSED.
        Child:  10.13 - F_TEST  [               3,               1] PASSED.
        Child:  10.14 - F_TEST  [               4,          ENDING] PASSED.
        Child:  10.15 - F_TEST  [               2,               1] PASSED.
        Child:  10.16 - F_TEST  [               0,               1] PASSED.

Test #11 - Make sure close() releases the process's locks.
        Parent: 11.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Child:  11.1  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: 11.3  - F_TLOCK [              1d,             5b7] PASSED.
        Parent: 11.4  - F_TLOCK [            2000,              57] PASSED.
        Parent: Closed testfile.
        Child:  11.5  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.6  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.7  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 13, 16 ].
        Parent: Closed testfile.
        Child:  11.8  - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.9  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Wrote '123456789abcdef' to testfile [ 0, 16 ].
        Parent: 11.10 - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Truncated testfile.
        Parent: Closed testfile.
        Child:  11.11 - F_TLOCK [               0,          ENDING] PASSED.
        Child:  11.12 - F_ULOCK [               0,          ENDING] PASSED.

Test #12 - Signalled process should release locks.
        Child:  12.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: Killed child process.
        Parent: 12.1  - F_TLOCK [               0,          ENDING] PASSED.

Test #13 - Check locking and mmap semantics.
        Parent: 13.0  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: 13.1  - mmap [               0,            1000] WARNING!
        Parent: **** Expected EAGAIN, returned success...
        Parent: 13.2  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: unmap testfile.
        Parent: 13.3  - mmap [               0,            1000] PASSED.
        Parent: 13.4  - F_TLOCK [             ffe,          ENDING] PASSED.
        Parent: unmap testfile.

Test #14 - Rate test performing I/O on unlocked and locked file.
        Parent: File Unlocked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [490.89 +/- 1.59 KB/s].
        Parent: 14.0  - F_TLOCK [               0,          ENDING] PASSED.
        Parent: File Locked
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Truncated testfile.
        Parent: Wrote and read 256 KB file 10 times; [460.43 +/- 6.94 KB/s].
        Parent: 14.1  - F_ULOCK [               0,          ENDING] PASSED.

Test #15 - Test 2nd open and I/O after lock and close.
        Parent: Second open succeeded.
        Parent: 15.0  - F_LOCK  [               0,          ENDING] PASSED.
        Parent: 15.1  - F_ULOCK [               0,          ENDING] PASSED.
        Parent: Closed testfile.
        Parent: Wrote 'abcdefghij' to testfile [ 0, 11 ].
        Parent: Read 'abcdefghij' from testfile [ 0, 11 ].
        Parent: 15.2  - COMPARE [               0,               b] PASSED.

** PARENT pass 1 results: 49/49 pass, 1/1 warn, 0/0 fail (pass/total).

**  CHILD pass 1 results: 64/64 pass, 0/0 warn, 0/0 fail (pass/total).
Congratulations, you passed the locking tests!

All tests completed

```

</details>

## Checklist
- [x] **Compilation:** _This patch does not break compilation_
- [x] **Merge conflicts:** _None_
- [x] **Code review:** _In progress_
- [x] **Sanity Testing:** _Completed as mentioned above_
- [ ] **Documentation:** _TBD_

Relevant PR's for this :
https://github.com/Seagate/cortx-posix/pull/299
https://github.com/Seagate/cortx-fs/pull/74